### PR TITLE
Added midi dataset

### DIFF
--- a/fuel/datasets/__init__.py
+++ b/fuel/datasets/__init__.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 from fuel.datasets.base import (Dataset, IterableDataset,
                                 IndexableDataset)
-
 from fuel.datasets.binarized_mnist import BinarizedMNIST
 from fuel.datasets.cifar10 import CIFAR10
 from fuel.datasets.mnist import MNIST

--- a/fuel/datasets/midi.py
+++ b/fuel/datasets/midi.py
@@ -1,0 +1,98 @@
+import os
+import numpy as np
+from collections import OrderedDict
+
+from fuel.utils import do_not_pickle_attributes
+from fuel.datasets import IndexableDataset
+from fuel import config
+
+@do_not_pickle_attributes('indexables')
+class MidiSequence(IndexableDataset):
+    def __init__(self, which_dataset, which_set='train', **kwargs):
+        '''Midi Datasets
+
+        Parameters
+        ---------
+
+        which_datset: str
+           one of the following 'jsb', 'midi', 'nottingham', 'muse'
+        which_set: str
+           which datset split 'train', 'valid' or 'test'
+
+        ref: Boulanger-Lewandowski et. al. Modeling Temporal Dependencies
+             in High-Dimensional Sequences: Application to Polyphonic
+             Music Generation and Transcription.
+             Download the dataset pickled datasets from here:
+             http://www-etud.iro.umontreal.ca/~boulanni/icml2012
+        '''
+        self.which_set = which_set
+        self.which_dataset = which_dataset
+
+        self.sources = ('features', 'targets')
+
+        super(MidiSequence, self).__init__(
+                OrderedDict(zip(self.sources,
+                                self._load_data(which_dataset, which_set))),
+                **kwargs)
+
+    def load(self):
+        self.indexables = [data[self.start:self.stop] for source, data
+                            in zip(self.provide_sources,
+                            self._load_data(
+                                self.which_dataset,
+                                self.which_set))
+                            ]
+
+    def _load_data(self, which_dataset, which_set):
+        """
+        which_dataset : choose between 'short' and 'long'
+        """
+        # Check which_set
+        if which_set not in ['train', 'valid', 'test']:
+            raise ValueError(which_set + " is not a recognized value. " +
+                        "Valid values are ['train', 'valid', 'test'].")
+        # Check which_dataset
+        if which_dataset not in ['midi', 'nottingham', 'muse', 'jsb']:
+            raise ValueError(which_set + " is not a recognized value. " +
+                "Valid values are ['midi', 'nottingham', 'muse', 'jsb'].")
+        _data_path = os.path.join(config.data_path, 'midi')
+        if which_dataset == 'midi':
+            _path = os.path.join(_data_path, "Piano-midi.de.pickle")
+            max_label= 108
+        elif which_dataset == 'nottingham':
+            _path = os.path.join(_data_path, "Nottingham.pickle")
+            max_label = 93
+        elif which_dataset == 'muse':
+            _path = os.path.join(_data_path, "MuseData.pickle")
+            max_label = 105
+        elif which_dataset == 'jsb':
+            _path = os.path.join(_data_path, "JSBChorales.pickle")
+            max_label = 96
+        data = np.load(_path)
+        raw = data[which_set]
+
+        features = np.asarray(
+                [np.asarray(
+                    [self.list_to_nparray(time_step,
+                    max_label) for time_step in np.asarray(raw[i][:-1])])
+                    for i in xrange(len(raw))]
+                    )
+        targets = np.asarray(
+            [np.asarray([self.list_to_nparray(time_step,
+                max_label) for time_step in np.asarray(raw[i][1:])])
+                for i in xrange(len(raw))]
+            )
+        return features, targets
+
+    def list_to_nparray(self, x, dim):
+        y = np.zeros((dim,), dtype=np.float32)
+        for i in x:
+            y[i - 1] = 1
+        return y
+
+    def get_data(self, state=None, request=None):
+        #batch = next(state)
+        batch = super(MidiSequence, self).get_data(state, request)
+        #if state is not None:
+        #batch = [b.transpose(1,0,2) for b in state[request]]
+        return batch

--- a/fuel/datasets/music.py
+++ b/fuel/datasets/music.py
@@ -6,6 +6,7 @@ from fuel.utils import do_not_pickle_attributes
 from fuel.datasets import IndexableDataset
 from fuel import config
 
+
 @do_not_pickle_attributes('indexables')
 class MusicSequence(IndexableDataset):
     def __init__(self, which_dataset, which_set='train', **kwargs):
@@ -23,30 +24,26 @@ class MusicSequence(IndexableDataset):
 
         self.sources = ('features', 'targets')
 
-        X = np.asarray(
-                [np.asarray(
-                    [self.list_to_nparray(time_step,
-                    max_label) for time_step in \
-                    np.asarray(raw[i][:-1])]) \
-                    for i in xrange(len(raw))]
-            )
+        X = np.asarray([np.asarray(
+                       [self.list_to_nparray(time_step,
+                        max_label) for time_step in
+                        np.asarray(raw[i][:-1])]) for i in xrange(len(raw))]
+                       )
         y = np.asarray(
-            [np.asarray([self.list_to_nparray(time_step,
-                max_label) for time_step in np.asarray(raw[i][1:])])
-                for i in xrange(len(raw))]
+            [np.asarray([self.list_to_nparray(time_step, max_label) for time_step in np.asarray(raw[i][1:])])
+             for i in xrange(len(raw))]
             )
 
-        super(MusicSequence, self).__init__(
-                OrderedDict(zip(self.sources, [X,y])),
-                **kwargs)
+        super(MusicSequence, self).__init__(OrderedDict(zip(self.sources, [X, y])),
+                                            **kwargs)
 
     def load(self):
         self.indexables = [data[self.start:self.stop] for source, data
-                            in zip(self.provide_sources,
-                            self._load_data(
-                                self.which_dataset,
-                                self.which_set))
-                            ]
+                           in zip(self.provide_sources,
+                           self._load_data(
+                               self.which_dataset,
+                               self.which_set))
+                           ]
 
     def _load_data(self, which_dataset, which_set):
         """
@@ -55,11 +52,11 @@ class MusicSequence(IndexableDataset):
         # Check which_set
         if which_set not in ['train', 'valid', 'test']:
             raise ValueError(which_set + " is not a recognized value. " +
-                        "Valid values are ['train', 'valid', 'test'].")
+                             "Valid values are ['train', 'valid', 'test'].")
         # Check which_dataset
         if which_dataset not in ['midi', 'nottingham', 'muse', 'jsb']:
             raise ValueError(which_set + " is not a recognized value. " +
-                "Valid values are ['midi', 'nottingham', 'muse', 'jsb'].")
+                             "Valid values are ['midi', 'nottingham', 'muse', 'jsb'].")
         _data_path = os.path.join(config.data_path, 'midi')
         if which_dataset == 'midi':
             _path = os.path.join(_data_path, "Piano-midi.de.pickle")

--- a/fuel/datasets/music.py
+++ b/fuel/datasets/music.py
@@ -1,0 +1,88 @@
+import os
+import numpy as np
+from collections import OrderedDict
+
+from fuel.utils import do_not_pickle_attributes
+from fuel.datasets import IndexableDataset
+from fuel import config
+
+@do_not_pickle_attributes('indexables')
+class MusicSequence(IndexableDataset):
+    def __init__(self, which_dataset, which_set='train', **kwargs):
+        self.which_set = which_set
+        self.which_dataset = which_dataset
+        raw = self._load_data(which_dataset, which_set)
+        if which_dataset == 'midi':
+            max_label = 108
+        elif which_dataset == 'nottingham':
+            max_label = 93
+        elif which_dataset == 'muse':
+            max_label = 105
+        elif which_dataset == 'jsb':
+            max_label = 96
+
+        self.sources = ('features', 'targets')
+
+        X = np.asarray(
+                [np.asarray(
+                    [self.list_to_nparray(time_step,
+                    max_label) for time_step in \
+                    np.asarray(raw[i][:-1])]) \
+                    for i in xrange(len(raw))]
+            )
+        y = np.asarray(
+            [np.asarray([self.list_to_nparray(time_step,
+                max_label) for time_step in np.asarray(raw[i][1:])])
+                for i in xrange(len(raw))]
+            )
+
+        super(MusicSequence, self).__init__(
+                OrderedDict(zip(self.sources, [X,y])),
+                **kwargs)
+
+    def load(self):
+        self.indexables = [data[self.start:self.stop] for source, data
+                            in zip(self.provide_sources,
+                            self._load_data(
+                                self.which_dataset,
+                                self.which_set))
+                            ]
+
+    def _load_data(self, which_dataset, which_set):
+        """
+        which_dataset : choose between 'short' and 'long'
+        """
+        # Check which_set
+        if which_set not in ['train', 'valid', 'test']:
+            raise ValueError(which_set + " is not a recognized value. " +
+                        "Valid values are ['train', 'valid', 'test'].")
+        # Check which_dataset
+        if which_dataset not in ['midi', 'nottingham', 'muse', 'jsb']:
+            raise ValueError(which_set + " is not a recognized value. " +
+                "Valid values are ['midi', 'nottingham', 'muse', 'jsb'].")
+        _data_path = os.path.join(config.data_path, 'midi')
+        if which_dataset == 'midi':
+            _path = os.path.join(_data_path, "Piano-midi.de.pickle")
+        elif which_dataset == 'nottingham':
+            _path = os.path.join(_data_path, "Nottingham.pickle")
+        elif which_dataset == 'muse':
+            _path = os.path.join(_data_path, "MuseData.pickle")
+        elif which_dataset == 'jsb':
+            _path = os.path.join(_data_path, "JSBChorales.pickle")
+        data = np.load(_path)
+        return data[which_set]
+
+    def list_to_nparray(self, x, dim):
+        y = np.zeros((dim,), dtype=np.float32)
+        for i in x:
+            y[i - 1] = 1
+        return y.transpose()
+    '''
+    def get_data(self, state=None, request=None):
+        #batch = next(state)
+        batch = super(MusicSequence, self).get_data(state, request)
+        print len(batch)
+        if state is not None:
+            batch = [b.transpose(1,0,2) for b in batch]
+        return tuple(batch)
+    '''

--- a/tests/test_midi_sequence.py
+++ b/tests/test_midi_sequence.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from fuel.datasets.midi import MidiSequence
+from fuel.streams import DataStream
+from fuel.schemes import SequentialScheme
+from fuel.transformers import Padding, Mapping
+
+def test_jsb():
+    jsb = MidiSequence('jsb')
+    print jsb.num_examples
+    dataset = DataStream(
+                jsb,
+                iteration_scheme=SequentialScheme(
+                               jsb.num_examples, 10
+                )
+              )
+    for b in dataset.get_epoch_iterator():
+        print b[0].shape
+
+    # This is how to prepare this dataset to be used in Blocks
+    dataset = Padding(dataset)
+    def _transpose(data):
+        return tuple(np.rollaxis(array,1,0) for array in data)
+    dataset = Mapping(dataset, _transpose)
+
+    for b in dataset.get_epoch_iterator():
+        print len(b)
+        print b[1].shape
+        print b[0].shape
+
+    assert b[0].shape == (108,9,96)
+if __name__ == '__main__':
+    test_jsb()


### PR DESCRIPTION
A dataset class for the midi collections mentioned on the deepleraning.net tutorials [here](http://deeplearning.net/tutorial/rnnrbm.html) and [here](http://www-etud.iro.umontreal.ca/~boulanni/icml2012)
This is code is adapted from the Pylearn2 dataset by @jych.

The included test shows the steps to prepera this for a blocks model (padding and transposing).

TODO in case this is interesting for the main repo:
- [ ] Add tests to travis.yaml
- [ ] Maybe a script to download the files to FUEL_DATA_PATH 
- [ ] Document it better