### PR TITLE
Mock HTTP responses in downloader tests

### DIFF
--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -242,7 +242,6 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     :hide:
     >>> import mock
     >>> import os
-    >>> import sys
     >>> from picklable_itertools import chain
     >>> from six.moves import range
     >>> from fuel.downloaders.base import default_downloader
@@ -260,7 +259,6 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     >>> fill_downloader_subparser(subparsers.add_parser('iris'))
     >>> args = parser.parse_args(['iris'])
     >>> args_dict = vars(args)
-    >>> args_dict['fd'] = sys.stdout
     >>> func = args_dict.pop('func')
     >>> content = b''
     >>> for i in range(50):

--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -240,18 +240,11 @@ You can now use the Iris dataset like you would use any other built-in dataset:
 
 .. doctest::
     :hide:
-    >>> from httmock import all_requests, HTTMock
-    >>> content = b''
-    >>> for i in range(50):
-    ...    content += b'0.0,0.0,0.0,0.0,Iris-setosa\n'
-    >>> for i in range(50):
-    ...    content += b'0.0,0.0,0.0,0.0,Iris-versicolor\n'
-    >>> for i in range(50):
-    ...    content += b'0.0,0.0,0.0,0.0,Iris-virginica\n'
-    >>> @all_requests
-    ... def response_content(url, request):
-    ...     return {'status_code': 200, 'content': content}
+    >>> import mock
     >>> import os
+    >>> import sys
+    >>> from picklable_itertools import chain
+    >>> from six.moves import range
     >>> from fuel.downloaders.base import default_downloader
     >>> def fill_downloader_subparser(subparser):
     ...     subparser.set_defaults(
@@ -267,9 +260,27 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     >>> fill_downloader_subparser(subparsers.add_parser('iris'))
     >>> args = parser.parse_args(['iris'])
     >>> args_dict = vars(args)
+    >>> args_dict['fd'] = sys.stdout
     >>> func = args_dict.pop('func')
-    >>> with HTTMock(response_content):
-    ...     func(**args_dict) # doctest: +ELLIPSIS
+    >>> content = b''
+    >>> for i in range(50):
+    ...    content += b'0.0,0.0,0.0,0.0,Iris-setosa\n'
+    >>> for i in range(50):
+    ...    content += b'0.0,0.0,0.0,0.0,Iris-versicolor\n'
+    >>> for i in range(50):
+    ...    content += b'0.0,0.0,0.0,0.0,Iris-virginica\n'
+    >>> length = len(content)
+    >>> @mock.patch('fuel.downloaders.base.requests')
+    ... def call_download(func, args_dict, mock_requests):
+    ...     mock_response = mock.Mock()
+    ...     mock_response.iter_content = mock.Mock(
+    ...         side_effect = lambda s: chain(
+    ...             (content[s * i: s * (i + 1)] for i in range(length // s)),
+    ...             (content[(length // s) * s:],)))
+    ...     mock_response.headers = {'content-length': length}
+    ...     mock_requests.get.return_value = mock_response
+    ...     func(**args_dict)
+    >>> call_download(func, args_dict) # doctest: +ELLIPSIS
     Downloading ...
 
 .. doctest::

--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -240,6 +240,17 @@ You can now use the Iris dataset like you would use any other built-in dataset:
 
 .. doctest::
     :hide:
+    >>> from httmock import all_requests, HTTMock
+    >>> content = b''
+    >>> for i in range(50):
+    ...    content += b'0.0,0.0,0.0,0.0,Iris-setosa\n'
+    >>> for i in range(50):
+    ...    content += b'0.0,0.0,0.0,0.0,Iris-versicolor\n'
+    >>> for i in range(50):
+    ...    content += b'0.0,0.0,0.0,0.0,Iris-virginica\n'
+    >>> @all_requests
+    ... def response_content(url, request):
+    ...     return {'status_code': 200, 'content': content}
     >>> import os
     >>> from fuel.downloaders.base import default_downloader
     >>> def fill_downloader_subparser(subparser):
@@ -257,7 +268,8 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     >>> args = parser.parse_args(['iris'])
     >>> args_dict = vars(args)
     >>> func = args_dict.pop('func')
-    >>> func(**args_dict) # doctest: +ELLIPSIS
+    >>> with HTTMock(response_content):
+    ...     func(**args_dict) # doctest: +ELLIPSIS
     Downloading ...
 
 .. doctest::

--- a/req-travis-conda.txt
+++ b/req-travis-conda.txt
@@ -5,3 +5,4 @@ pandas==0.16.1
 pytables=3.1.1
 six==1.9.0
 pyzmq==14.6.0
+mock==1.0.1

--- a/req-travis-pip.txt
+++ b/req-travis-pip.txt
@@ -1,3 +1,2 @@
 nose2[coverage-plugin]==0.5.0
 coveralls==0.5
-httmock==1.2.3

--- a/req-travis-pip.txt
+++ b/req-travis-pip.txt
@@ -1,2 +1,3 @@
 nose2[coverage-plugin]==0.5.0
 coveralls==0.5
+httmock=1.2.3

--- a/req-travis-pip.txt
+++ b/req-travis-pip.txt
@@ -1,3 +1,3 @@
 nose2[coverage-plugin]==0.5.0
 coveralls==0.5
-httmock=1.2.3
+httmock==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,8 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=['six', 'picklable_itertools', 'pyyaml', 'h5py',
                       'tables', 'progressbar2', 'pyzmq'],
+    extras_require={
+        'test': ['nose', 'nose2', 'httmock']
+    },
     scripts=['bin/fuel-convert', 'bin/fuel-download', 'bin/fuel-info']
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=['six', 'picklable_itertools', 'pyyaml', 'h5py',
                       'tables', 'progressbar2', 'pyzmq'],
     extras_require={
-        'test': ['nose', 'nose2', 'httmock']
+        'test': ['nose', 'nose2', 'mock']
     },
     scripts=['bin/fuel-convert', 'bin/fuel-download', 'bin/fuel-info']
 )

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -19,7 +19,7 @@ mock_content = b'mock'
 @all_requests
 def response_content(url, request):
     """Mocks an HTTP response."""
-    return {'status_code': 200, 'content': b'mock'}
+    return {'status_code': 200, 'content': mock_content}
 
 @all_requests
 def response_content_disposition(url, request):

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import sys
 import tempfile
+from functools import wraps
 
 from numpy.testing import assert_equal, assert_raises
 
@@ -20,29 +21,32 @@ mock_content = b'mock'
 
 def mock_requests(content_disposition=False, content_length=True):
     def mock_decorator(func):
-        with mock.patch('fuel.downloaders.base.requests') as mock_requests:
-            def wrapper_func(*args, **kwargs):
-                length = len(mock_content)
-                mock_response = mock.Mock()
-                mock_response.iter_content = mock.Mock(
-                    side_effect=lambda s: chain(
-                        (mock_content[s * i: s * (i + 1)]
-                         for i in range(length // s)),
-                        (mock_content[(length // s) * s:],)))
-                mock_response.headers = {}
-                if content_length:
-                    mock_response.headers['content-length'] = length
-                if content_disposition:
-                    cd = 'attachment; filename={}'.format(mock_filename)
-                    mock_response.headers['content-disposition'] = cd
-                mock_requests.get.return_value = mock_response
-                return func(*args, **kwargs)
+        @wraps(func)
+        @mock.patch('fuel.downloaders.base.requests')
+        def wrapper_func(*args, **kwargs):
+            mock_requests = args[-1]
+            args = args[:-1]
+            length = len(mock_content)
+            mock_response = mock.Mock()
+            mock_response.iter_content = mock.Mock(
+                side_effect=lambda s: chain(
+                    (mock_content[s * i: s * (i + 1)]
+                     for i in range(length // s)),
+                    (mock_content[(length // s) * s:],)))
+            mock_response.headers = {}
+            if content_length:
+                mock_response.headers['content-length'] = length
+            if content_disposition:
+                cd = 'attachment; filename={}'.format(mock_filename)
+                mock_response.headers['Content-Disposition'] = cd
+            mock_requests.get.return_value = mock_response
+            return func(*args, **kwargs)
         return wrapper_func
     return mock_decorator
 
 
 class TestFilenameFromURL(object):
-    @mock_requests
+    @mock_requests()
     def test_no_content_disposition(self):
         assert_equal(filename_from_url(mock_url), mock_filename)
 
@@ -52,8 +56,15 @@ class TestFilenameFromURL(object):
 
 
 class TestDownload(object):
-    @mock_requests
+    @mock_requests()
     def test_download_content(self):
+        with tempfile.SpooledTemporaryFile() as f:
+            download(mock_url, f, fd=sys.stdout)
+            f.seek(0)
+            assert_equal(f.read(), mock_content)
+
+    @mock_requests(content_length=False)
+    def test_download_content_no_length(self):
         with tempfile.SpooledTemporaryFile() as f:
             download(mock_url, f, fd=sys.stdout)
             f.seek(0)
@@ -107,7 +118,7 @@ class TestDefaultDownloader(object):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
-    @mock_requests
+    @mock_requests()
     def test_default_downloader_save_with_filename(self):
         args = dict(directory=self.tempdir, clear=False, urls=[mock_url],
                     filenames=[mock_filename], fd=sys.stdout)
@@ -115,7 +126,7 @@ class TestDefaultDownloader(object):
         with open(self.filepath, 'rb') as f:
             assert_equal(f.read(), mock_content)
 
-    @mock_requests
+    @mock_requests()
     def test_default_downloader_save_no_filename(self):
         args = dict(directory=self.tempdir, clear=False, urls=[mock_url],
                     filenames=[None], fd=sys.stdout)
@@ -123,7 +134,7 @@ class TestDefaultDownloader(object):
         with open(self.filepath, 'rb') as f:
             assert_equal(f.read(), mock_content)
 
-    @mock_requests
+    @mock_requests()
     def test_default_downloader_save_no_url_url_prefix(self):
         args = dict(directory=self.tempdir, clear=False, urls=[None],
                     filenames=[mock_filename], url_prefix=mock_url[:-9],
@@ -132,19 +143,19 @@ class TestDefaultDownloader(object):
         with open(self.filepath, 'rb') as f:
             assert_equal(f.read(), mock_content)
 
-    @mock_requests
+    @mock_requests()
     def test_default_downloader_save_no_url_no_url_prefix(self):
         args = dict(directory=self.tempdir, clear=False, urls=[None],
                     filenames=[mock_filename], fd=sys.stdout)
         assert_raises(NeedURLPrefix, default_downloader, **args)
 
-    @mock_requests
+    @mock_requests()
     def test_default_downloader_save_no_filename_for_url(self):
         args = dict(directory=self.tempdir, clear=False, urls=[mock_url[:-9]],
                     filenames=[None], fd=sys.stdout)
         assert_raises(ValueError, default_downloader, **args)
 
-    @mock_requests
+    @mock_requests()
     def test_default_downloader_clear(self):
         file_path = os.path.join(self.tempdir, 'tmp.data')
         open(file_path, 'a').close()

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -59,14 +59,14 @@ class TestDownload(object):
     @mock_requests()
     def test_download_content(self):
         with tempfile.SpooledTemporaryFile() as f:
-            download(mock_url, f, fd=sys.stdout)
+            download(mock_url, f)
             f.seek(0)
             assert_equal(f.read(), mock_content)
 
     @mock_requests(content_length=False)
     def test_download_content_no_length(self):
         with tempfile.SpooledTemporaryFile() as f:
-            download(mock_url, f, fd=sys.stdout)
+            download(mock_url, f)
             f.seek(0)
             assert_equal(f.read(), mock_content)
 
@@ -121,7 +121,7 @@ class TestDefaultDownloader(object):
     @mock_requests()
     def test_default_downloader_save_with_filename(self):
         args = dict(directory=self.tempdir, clear=False, urls=[mock_url],
-                    filenames=[mock_filename], fd=sys.stdout)
+                    filenames=[mock_filename])
         default_downloader(**args)
         with open(self.filepath, 'rb') as f:
             assert_equal(f.read(), mock_content)
@@ -129,7 +129,7 @@ class TestDefaultDownloader(object):
     @mock_requests()
     def test_default_downloader_save_no_filename(self):
         args = dict(directory=self.tempdir, clear=False, urls=[mock_url],
-                    filenames=[None], fd=sys.stdout)
+                    filenames=[None])
         default_downloader(**args)
         with open(self.filepath, 'rb') as f:
             assert_equal(f.read(), mock_content)
@@ -137,8 +137,7 @@ class TestDefaultDownloader(object):
     @mock_requests()
     def test_default_downloader_save_no_url_url_prefix(self):
         args = dict(directory=self.tempdir, clear=False, urls=[None],
-                    filenames=[mock_filename], url_prefix=mock_url[:-9],
-                    fd=sys.stdout)
+                    filenames=[mock_filename], url_prefix=mock_url[:-9])
         default_downloader(**args)
         with open(self.filepath, 'rb') as f:
             assert_equal(f.read(), mock_content)
@@ -146,13 +145,13 @@ class TestDefaultDownloader(object):
     @mock_requests()
     def test_default_downloader_save_no_url_no_url_prefix(self):
         args = dict(directory=self.tempdir, clear=False, urls=[None],
-                    filenames=[mock_filename], fd=sys.stdout)
+                    filenames=[mock_filename])
         assert_raises(NeedURLPrefix, default_downloader, **args)
 
     @mock_requests()
     def test_default_downloader_save_no_filename_for_url(self):
         args = dict(directory=self.tempdir, clear=False, urls=[mock_url[:-9]],
-                    filenames=[None], fd=sys.stdout)
+                    filenames=[None])
         assert_raises(ValueError, default_downloader, **args)
 
     @mock_requests()
@@ -160,6 +159,6 @@ class TestDefaultDownloader(object):
         file_path = os.path.join(self.tempdir, 'tmp.data')
         open(file_path, 'a').close()
         args = dict(directory=self.tempdir, clear=True, urls=[None],
-                    filenames=['tmp.data'], fd=sys.stdout)
+                    filenames=['tmp.data'])
         default_downloader(**args)
         assert not os.path.isfile(file_path)

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -25,7 +25,7 @@ def mock_requests(content_disposition=False, content_length=True):
                 length = len(mock_content)
                 mock_response = mock.Mock()
                 mock_response.iter_content = mock.Mock(
-                    side_effect = lambda s: chain(
+                    side_effect=lambda s: chain(
                         (mock_content[s * i: s * (i + 1)]
                          for i in range(length // s)),
                         (mock_content[(length // s) * s:],)))

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -2,7 +2,6 @@ import argparse
 import mock
 import os
 import shutil
-import sys
 import tempfile
 from functools import wraps
 

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -21,6 +21,7 @@ def response_content(url, request):
     """Mocks an HTTP response."""
     return {'status_code': 200, 'content': mock_content}
 
+
 @all_requests
 def response_content_disposition(url, request):
     """Mocks an HTTP response with a content-disposition header."""


### PR DESCRIPTION
With this the Fuel test suite should be able to run offline as well.

Plus it speeds up test execution, which is always a good thing. :)