### PR TITLE
removed flatten parameter from H5DPYDataset docs

### DIFF
--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -111,8 +111,6 @@ class H5PYDataset(Dataset):
         at the moment, `slice.step` must be either 1 or `None`.**
     load_in_memory : bool, optional
         Whether to load the data in main memory. Defaults to `False`.
-    flatten : list of str, optional
-        Which sources to flatten as a 2D array, if any. Defaults to `None`.
     driver : str, optional
         Low-level driver to use. Defaults to `None`. See h5py
         documentation for a complete list of available options.


### PR DESCRIPTION
It appears the flatten argument in the `H5DPYDataset` object was removed but the docs were left. The relevant commit is: https://github.com/mila-udem/fuel/commit/79073b9358817384e005774aec3ee6e2586a4053.
This removes the parameter from doc string.