### PR TITLE
[WIP] Index subset support for H5PYDataset

### DIFF
--- a/docs/h5py_dataset.rst
+++ b/docs/h5py_dataset.rst
@@ -229,25 +229,29 @@ Playing with H5PYDataset datasets
 
 Let's explore what we can do with the dataset we just created.
 
-The simplest thing is to load it by giving its path and a split name:
+The simplest thing is to load it by giving its path and a tuple of split names:
 
->>> train_set = H5PYDataset('dataset.hdf5', which_set='train')
+>>> train_set = H5PYDataset('dataset.hdf5', which_set=('train',))
 >>> print(train_set.num_examples)
 90
->>> test_set = H5PYDataset('dataset.hdf5', which_set='test')
+>>> test_set = H5PYDataset('dataset.hdf5', which_set=('test',))
 >>> print(test_set.num_examples)
 10
+
+Passing more than one split name would cause the splits to be concatenated.
+The available data sources would be the intersection of the sources provided
+by each split.
 
 You can further restrict which examples are used by providing a ``slice`` object
 as the ``subset`` argument. *Make sure that its* ``step`` *is either 1 or*
 ``None`` *, as these are the only two options that are supported*.
 
 >>> train_set = H5PYDataset(
-...     'dataset.hdf5', which_set='train', subset=slice(0, 80))
+...     'dataset.hdf5', which_set=('train',), subset=slice(0, 80))
 >>> print(train_set.num_examples)
 80
 >>> valid_set = H5PYDataset(
-...     'dataset.hdf5', which_set='train', subset=slice(80, 90))
+...     'dataset.hdf5', which_set=('train',), subset=slice(80, 90))
 >>> print(valid_set.num_examples)
 10
 
@@ -279,7 +283,7 @@ We can request data as usual:
 We can also request just the vector features:
 
 >>> train_vector_features = H5PYDataset(
-...     'dataset.hdf5', which_set='train', subset=slice(0, 80),
+...     'dataset.hdf5', which_set=('train',), subset=slice(0, 80),
 ...     sources=['vector_features'])
 >>> handle = train_vector_features.open()
 >>> data, = train_vector_features.get_data(handle, slice(0, 10))
@@ -299,7 +303,7 @@ In :class:`~.datasets.hdf5.H5PYDataset`, this is accomplished via the
 what you requested, and nothing more.
 
 >>> in_memory_train_vector_features = H5PYDataset(
-...     'dataset.hdf5', which_set='train', subset=slice(0, 80),
+...     'dataset.hdf5', which_set=('train',), subset=slice(0, 80),
 ...     sources=['vector_features'], load_in_memory=True)
 >>> data, = in_memory_train_vector_features.data_sources
 >>> print(type(data)) # doctest: +ELLIPSIS
@@ -345,7 +349,7 @@ we arbitrarily chose ``-1`` for both.
 Let's check that the training and test set do contain even and odd examples:
 
 >>> train_set = H5PYDataset(
-...     'dataset.hdf5', which_set='train', sources=('vector_features',))
+...     'dataset.hdf5', which_set=('train',), sources=('vector_features',))
 >>> handle = train_set.open()
 >>> print(
 ...     numpy.array_equal(
@@ -356,7 +360,7 @@ Let's check that the training and test set do contain even and odd examples:
 True
 >>> train_set.close(handle)
 >>> test_set = H5PYDataset(
-...     'dataset.hdf5', which_set='test', sources=('vector_features',))
+...     'dataset.hdf5', which_set=('test',), sources=('vector_features',))
 >>> handle = test_set.open()
 >>> print(
 ...     numpy.array_equal(
@@ -463,7 +467,7 @@ That's it. Now let's kick the tires a little. The axis labels appear as they
 should:
 
 >>> train_set = H5PYDataset(
-...     'dataset.hdf5', which_set='train', sources=('image_features',))
+...     'dataset.hdf5', which_set=('train',), sources=('image_features',))
 >>> print(train_set.axis_labels['image_features'])
 ('batch', 'channel', 'height', 'width')
 

--- a/docs/h5py_dataset.rst
+++ b/docs/h5py_dataset.rst
@@ -248,8 +248,7 @@ The available data sources would be the intersection of the sources provided
 by each split.
 
 You can further restrict which examples are used by providing a ``slice`` object
-as the ``subset`` argument. *Make sure that its* ``step`` *is either 1 or*
-``None`` *, as these are the only two options that are supported*.
+or a list of indices as the ``subset`` argument.
 
 >>> train_set = H5PYDataset(
 ...     'dataset.hdf5', which_sets=('train',), subset=slice(0, 80))

--- a/docs/h5py_dataset.rst
+++ b/docs/h5py_dataset.rst
@@ -62,11 +62,16 @@ things if your data happens to meet these assumptions:
 
   1. ``split`` : string identifier for the split name
   2. ``source`` : string identifier for the source name
-  3. ``start`` : start index (inclusive) of the split in the source array
-  4. ``stop`` : stop index (exclusive) of the split in the source array
-  4. ``indices`` : reference pointing to a dataset containing indices for this split/source pair
-  5. ``available`` : boolean, ``False`` if this split is not available for this source
-  6. ``comment`` : comment string
+  3. ``start`` : start index (inclusive) of the split in the source
+     array, used if ``indices`` is a null reference.
+  4. ``stop`` : stop index (exclusive) of the split in the source
+     array, used if ``indices`` is a null reference.
+  5. ``indices`` : h5py.Reference, reference to a dataset containing
+     subset indices for this split/source pair. If it's a null
+     reference, ``start`` and ``stop`` are used.
+  6. ``available`` : boolean, ``False`` is this split is not available
+     for this source
+  7. ``comment`` : comment string
 
 .. tip::
 

--- a/docs/h5py_dataset.rst
+++ b/docs/h5py_dataset.rst
@@ -231,10 +231,10 @@ Let's explore what we can do with the dataset we just created.
 
 The simplest thing is to load it by giving its path and a tuple of split names:
 
->>> train_set = H5PYDataset('dataset.hdf5', which_set=('train',))
+>>> train_set = H5PYDataset('dataset.hdf5', which_sets=('train',))
 >>> print(train_set.num_examples)
 90
->>> test_set = H5PYDataset('dataset.hdf5', which_set=('test',))
+>>> test_set = H5PYDataset('dataset.hdf5', which_sets=('test',))
 >>> print(test_set.num_examples)
 10
 
@@ -247,11 +247,11 @@ as the ``subset`` argument. *Make sure that its* ``step`` *is either 1 or*
 ``None`` *, as these are the only two options that are supported*.
 
 >>> train_set = H5PYDataset(
-...     'dataset.hdf5', which_set=('train',), subset=slice(0, 80))
+...     'dataset.hdf5', which_sets=('train',), subset=slice(0, 80))
 >>> print(train_set.num_examples)
 80
 >>> valid_set = H5PYDataset(
-...     'dataset.hdf5', which_set=('train',), subset=slice(80, 90))
+...     'dataset.hdf5', which_sets=('train',), subset=slice(80, 90))
 >>> print(valid_set.num_examples)
 10
 
@@ -283,7 +283,7 @@ We can request data as usual:
 We can also request just the vector features:
 
 >>> train_vector_features = H5PYDataset(
-...     'dataset.hdf5', which_set=('train',), subset=slice(0, 80),
+...     'dataset.hdf5', which_sets=('train',), subset=slice(0, 80),
 ...     sources=['vector_features'])
 >>> handle = train_vector_features.open()
 >>> data, = train_vector_features.get_data(handle, slice(0, 10))
@@ -303,7 +303,7 @@ In :class:`~.datasets.hdf5.H5PYDataset`, this is accomplished via the
 what you requested, and nothing more.
 
 >>> in_memory_train_vector_features = H5PYDataset(
-...     'dataset.hdf5', which_set=('train',), subset=slice(0, 80),
+...     'dataset.hdf5', which_sets=('train',), subset=slice(0, 80),
 ...     sources=['vector_features'], load_in_memory=True)
 >>> data, = in_memory_train_vector_features.data_sources
 >>> print(type(data)) # doctest: +ELLIPSIS
@@ -349,7 +349,7 @@ we arbitrarily chose ``-1`` for both.
 Let's check that the training and test set do contain even and odd examples:
 
 >>> train_set = H5PYDataset(
-...     'dataset.hdf5', which_set=('train',), sources=('vector_features',))
+...     'dataset.hdf5', which_sets=('train',), sources=('vector_features',))
 >>> handle = train_set.open()
 >>> print(
 ...     numpy.array_equal(
@@ -360,7 +360,7 @@ Let's check that the training and test set do contain even and odd examples:
 True
 >>> train_set.close(handle)
 >>> test_set = H5PYDataset(
-...     'dataset.hdf5', which_set=('test',), sources=('vector_features',))
+...     'dataset.hdf5', which_sets=('test',), sources=('vector_features',))
 >>> handle = test_set.open()
 >>> print(
 ...     numpy.array_equal(
@@ -467,7 +467,7 @@ That's it. Now let's kick the tires a little. The axis labels appear as they
 should:
 
 >>> train_set = H5PYDataset(
-...     'dataset.hdf5', which_set=('train',), sources=('image_features',))
+...     'dataset.hdf5', which_sets=('train',), sources=('image_features',))
 >>> print(train_set.axis_labels['image_features'])
 ('batch', 'channel', 'height', 'width')
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,7 +75,7 @@ For example, after downloading the MNIST data to ``/home/your_data/mnist`` we
 construct a handle to the data.
 
 >>> from fuel.datasets import MNIST
->>> mnist = MNIST(which_set=('train',))
+>>> mnist = MNIST(which_sets=('train',))
 
 In order to start reading the data, we need to initialize a *data stream*. A
 data stream combines a dataset with a particular iteration scheme to read data

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,7 +75,7 @@ For example, after downloading the MNIST data to ``/home/your_data/mnist`` we
 construct a handle to the data.
 
 >>> from fuel.datasets import MNIST
->>> mnist = MNIST(which_set='train')
+>>> mnist = MNIST(which_set=('train',))
 
 In order to start reading the data, we need to initialize a *data stream*. A
 data stream combines a dataset with a particular iteration scheme to read data

--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -342,7 +342,7 @@ You can now use the Iris dataset like you would use any other built-in dataset:
 .. doctest::
 
     >>> from fuel.datasets.iris import Iris # doctest: +SKIP
-    >>> train_set = Iris('train')
+    >>> train_set = Iris(('train',))
     >>> print(train_set.axis_labels['features'])
     ('batch', 'feature')
     >>> print(train_set.axis_labels['targets'])

--- a/fuel/converters/base.py
+++ b/fuel/converters/base.py
@@ -110,7 +110,7 @@ def fill_hdf5_file(h5file, data):
         dataset[...] = numpy.concatenate([s[2] for s in splits], axis=0)
         for i, j, s in zip(indices[:-1], indices[1:], splits):
             if len(s) == 4:
-                split_dict[s[0]][name] = (i, j, s[3])
+                split_dict[s[0]][name] = (i, j, None, s[3])
             else:
                 split_dict[s[0]][name] = (i, j)
     h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)

--- a/fuel/datasets/binarized_mnist.py
+++ b/fuel/datasets/binarized_mnist.py
@@ -34,16 +34,17 @@ class BinarizedMNIST(H5PYDataset):
 
     Parameters
     ----------
-    which_set : 'train' or 'valid' or 'test'
-        Whether to load the training set (50,000 samples) or the validation
-        set (10,000 samples) or the test set (10,000 samples).
+    which_sets : tuple of str
+        Which split to load. Valid values are 'train', 'valid' and 'test',
+        corresponding to the training set (50,000 examples), the validation
+        set (10,000 samples) and the test set (10,000 examples).
 
     """
     filename = 'binarized_mnist.hdf5'
 
-    def __init__(self, which_set, load_in_memory=True, **kwargs):
+    def __init__(self, which_sets, load_in_memory=True, **kwargs):
         super(BinarizedMNIST, self).__init__(
-            self.data_path, which_set=which_set,
+            self.data_path, which_sets=which_sets,
             load_in_memory=load_in_memory, **kwargs)
 
     @property

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -23,19 +23,20 @@ class CIFAR10(H5PYDataset):
 
     Parameters
     ----------
-    which_set : 'train' or 'test'
-        Whether to load the training set (50,000 samples) or the test set
-        (10,000 samples). Note that CIFAR10 does not have a validation
-        set; usually you will create your own training/validation split
-        using the `subset` argument.
+    which_sets : tuple of str
+        Which split to load. Valid values are 'train' and 'test',
+        corresponding to the training set (50,000 examples) and the test
+        set (10,000 examples). Note that CIFAR10 does not have a
+        validation set; usually you will create your own
+        training/validation split using the `subset` argument.
 
     """
     filename = 'cifar10.hdf5'
     default_transformers = uint8_pixels_to_floatX(('features',))
 
-    def __init__(self, which_set, **kwargs):
+    def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', True)
-        super(CIFAR10, self).__init__(self.data_path, which_set, **kwargs)
+        super(CIFAR10, self).__init__(self.data_path, which_sets, **kwargs)
 
     @property
     def data_path(self):

--- a/fuel/datasets/cifar100.py
+++ b/fuel/datasets/cifar100.py
@@ -29,19 +29,20 @@ class CIFAR100(H5PYDataset):
 
     Parameters
     ----------
-    which_set : 'train' or 'test'
-        Whether to load the training set (50,000 samples) or the test set
-        (10,000 samples). Note that CIFAR100 does not have a validation
-        set; usually you will create your own training/validation split
-        using the start and stop arguments.
+    which_sets : tuple of str
+        Which split to load. Valid values are 'train' and 'test',
+        corresponding to the training set (50,000 examples) and the test
+        set (10,000 examples). Note that CIFAR100 does not have a
+        validation set; usually you will create your own
+        training/validation split using the `subset` argument.
 
     """
     filename = 'cifar100.hdf5'
     default_transformers = uint8_pixels_to_floatX(('features',))
 
-    def __init__(self, which_set, **kwargs):
+    def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', True)
-        super(CIFAR100, self).__init__(self.data_path, which_set, **kwargs)
+        super(CIFAR100, self).__init__(self.data_path, which_sets, **kwargs)
 
     @property
     def data_path(self):

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 import h5py
 import numpy
+import six
 import tables
 from six.moves import zip, range
 
@@ -117,7 +118,7 @@ class H5PYDataset(Dataset):
     ----------
     file_or_path : :class:`h5py.File` or str
         HDF5 file handle, or path to the HDF5 file.
-    which_set : str or tuple of str
+    which_set : iterable of str
         Which split(s) to use. If one than more split is requested,
         the provided sources will be the intersection of provided
         sources for these splits.
@@ -169,8 +170,11 @@ class H5PYDataset(Dataset):
         else:
             self.path = file_or_path
             self.external_file_handle = None
-        if not isinstance(which_set, (list, tuple)):
-            which_set = (which_set,)
+        which_set_invalid_value = (
+            isinstance(which_set, six.string_types) or
+            not all(isinstance(s, six.string_types) for s in which_set))
+        if which_set_invalid_value:
+            raise ValueError('`which_set` should be an iterable of strings')
         self.which_set = which_set
         subset = subset if subset else slice(None)
         if hasattr(subset, 'step') and subset.step not in (1, None):

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -1,5 +1,5 @@
 from itertools import product
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 
 import h5py
 import numpy
@@ -186,6 +186,7 @@ class H5PYDataset(Dataset):
         * `provides_sources`
         * `vlen_sources`
         * `default_axis_labels`
+
         """
         self._out_of_memory_open()
         handle = self._file_handle

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -131,11 +131,14 @@ class H5PYDataset(Dataset):
         Low-level driver to use. Defaults to `None`. See h5py
         documentation for a complete list of available options.
     sort_indices : bool, optional
-        Whether to explicitly sort requested indices when data is
-        requested in the form of a list of indices. Defaults to `True`.
-        This flag can be set to `False` for greater performance. In
-        that case, it is the user's responsibility to make sure that
-        indices are ordered.
+        HDF5 doesn't support fancy indexing with an unsorted list of
+        indices. In order to allow that, the dataset can sort the list
+        of indices, access the data in sorted order and shuffle back
+        the data in the unsorted order. Setting this flag to `True`
+        (the default) will activate this behaviour. For greater
+        performance, set this flag to `False`. Note that in that case,
+        it is the user's responsibility to make sure that indices are
+        ordered.
 
     Attributes
     ----------

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -103,11 +103,12 @@ class H5PYDataset(Dataset):
       1. ``split`` : string identifier for the split name
       2. ``source`` : string identifier for the source name
       3. ``start`` : start index (inclusive) of the split in the source
-         array
+         array, used if ``indices`` is a null reference.
       4. ``stop`` : stop index (exclusive) of the split in the source
-         array
+         array, used if ``indices`` is a null reference.
       6. ``indices`` : h5py.Reference, reference to a dataset containing
-         subset indices for this split/source pair.
+         subset indices for this split/source pair. If it's a null
+         reference, ``start`` and ``stop`` are used.
       6. ``available`` : boolean, ``False`` is this split is not available
          for this source
       7. ``comment`` : comment string

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -107,7 +107,7 @@ class H5PYDataset(Dataset):
          array, used if ``indices`` is a null reference.
       4. ``stop`` : stop index (exclusive) of the split in the source
          array, used if ``indices`` is a null reference.
-      6. ``indices`` : h5py.Reference, reference to a dataset containing
+      5. ``indices`` : h5py.Reference, reference to a dataset containing
          subset indices for this split/source pair. If it's a null
          reference, ``start`` and ``stop`` are used.
       6. ``available`` : boolean, ``False`` is this split is not available

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -631,7 +631,7 @@ class H5PYDataset(Dataset):
         handle = self._file_handle
         for source_name, subset in zip(self.sources, self.subsets):
             if hasattr(subset, 'step'):
-                if isinstance(request, slice):
+                if hasattr(request, 'step'):
                     req = slice(request.start + subset.start,
                                 request.stop + subset.start, request.step)
                 else:

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -121,7 +121,9 @@ class H5PYDataset(Dataset):
     which_sets : iterable of str
         Which split(s) to use. If one than more split is requested,
         the provided sources will be the intersection of provided
-        sources for these splits.
+        sources for these splits. **Note: for all splits that are
+        specified as a list of indices, those indices will get sorted
+        no matter what.**
     subset : slice, optional
         A slice of data *within the context of the split* to use. Defaults
         to `None`, in which case the whole split is used. **Note:

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -133,7 +133,7 @@ class H5PYDataset(Dataset):
         indices are ordered.
 
     """
-    interface_version = '0.2'
+    interface_version = '0.3'
     _ref_counts = defaultdict(int)
     _file_handles = {}
 
@@ -186,7 +186,7 @@ class H5PYDataset(Dataset):
         for split in split_dict.values():
             sources |= set(split.keys())
             for val in split.values():
-                if len(val) == 3:
+                if len(val) == 4:
                     comment_len = max([comment_len, len(val[-1])])
         sources = sorted(list(sources))
         source_len = max(len(source) for source in sources)
@@ -197,7 +197,9 @@ class H5PYDataset(Dataset):
             dtype=numpy.dtype([
                 ('split', 'a', split_len),
                 ('source', 'a', source_len),
-                ('start', numpy.int64, 1), ('stop', numpy.int64, 1),
+                ('start', numpy.int64, 1),
+                ('stop', numpy.int64, 1),
+                ('indices', h5py.special_dtype(ref=h5py.Reference)),
                 ('available', numpy.bool, 1),
                 ('comment', 'a', comment_len)]))
 
@@ -206,19 +208,24 @@ class H5PYDataset(Dataset):
             if source in split_dict[split]:
                 start, stop = split_dict[split][source][:2]
                 available = True
+                indices = h5py.Reference()
                 # Workaround for bug when pickling an empty string
                 comment = '.'
-                if len(split_dict[split][source]) == 3:
-                    comment = split_dict[split][source][2]
+                if len(split_dict[split][source]) > 2:
+                    indices = split_dict[split][source][2]
+                if len(split_dict[split][source]) > 3:
+                    comment = split_dict[split][source][3]
                     if not comment:
                         comment = '.'
             else:
-                (start, stop, available, comment) = (0, 0, False, '.')
+                (start, stop, indices, available, comment) = (
+                    0, 0, h5py.Reference(), False, '.')
             # Workaround for H5PY being unable to store unicode type
             split_array[i]['split'] = split.encode('utf8')
             split_array[i]['source'] = source.encode('utf8')
             split_array[i]['start'] = start
             split_array[i]['stop'] = stop
+            split_array[i]['indices'] = indices
             split_array[i]['available'] = available
             split_array[i]['comment'] = comment.encode('utf8')
 
@@ -228,14 +235,14 @@ class H5PYDataset(Dataset):
     def parse_split_array(split_array):
         split_dict = OrderedDict()
         for row in split_array:
-            split, source, start, stop, available, comment = row
+            split, source, start, stop, indices, available, comment = row
             split = split.decode('utf8')
             source = source.decode('utf8')
             comment = comment.decode('utf8')
             if available:
                 if split not in split_dict:
                     split_dict[split] = OrderedDict()
-                split_dict[split][source] = (start, stop, comment)
+                split_dict[split][source] = (start, stop, indices, comment)
         return split_dict
 
     @staticmethod
@@ -271,15 +278,7 @@ class H5PYDataset(Dataset):
         if not hasattr(self, '_split_dict'):
             self._out_of_memory_open()
             handle = self._file_handle
-            split_array = []
-            for row in handle.attrs['split']:
-                split, source, start, stop, available, comment = row
-                if start < 0 and stop < 0:
-                    stop = handle[
-                        handle[source].attrs[
-                            '{}_subset'.format(split.decode('utf8'))]][...]
-                split_array.append(
-                    (split, source, start, stop, available, comment))
+            split_array = handle.attrs['split']
             self._split_dict = H5PYDataset.parse_split_array(split_array)
             self._out_of_memory_close()
         return self._split_dict
@@ -328,12 +327,15 @@ class H5PYDataset(Dataset):
     @property
     def subsets(self):
         if not hasattr(self, '_subsets'):
+            self._out_of_memory_open()
+            handle = self._file_handle
             subsets = [self._subset_template for source in self.sources]
             num_examples = None
             for i, source_name in enumerate(self.sources):
-                start, stop = self.split_dict[self.which_set][source_name][:2]
-                if start < 0:
-                    source_subset = stop
+                start, stop, indices = self.split_dict[
+                    self.which_set][source_name][:3]
+                if indices:
+                    source_subset = handle[indices]
                 else:
                     source_subset = slice(start, stop)
                 subset = subsets[i]
@@ -357,6 +359,7 @@ class H5PYDataset(Dataset):
                 if num_examples != subset_num_examples:
                     raise ValueError("sources have different lengths")
             self._subsets = subsets
+            self._out_of_memory_close()
         return self._subsets
 
     def load(self):

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -276,7 +276,8 @@ class H5PYDataset(Dataset):
                 split, source, start, stop, available, comment = row
                 if start < 0 and stop < 0:
                     stop = handle[
-                        handle[source].attrs['{}_subset'.format(split.decode('utf8'))]][...]
+                        handle[source].attrs[
+                            '{}_subset'.format(split.decode('utf8'))]][...]
                 split_array.append(
                     (split, source, start, stop, available, comment))
             self._split_dict = H5PYDataset.parse_split_array(split_array)

--- a/fuel/datasets/mnist.py
+++ b/fuel/datasets/mnist.py
@@ -23,17 +23,18 @@ class MNIST(H5PYDataset):
 
     Parameters
     ----------
-    which_set : 'train' or 'test'
-        Whether to load the training set (60,000 samples) or the test set
-        (10,000 samples).
+    which_sets : tuple of str
+        Which split to load. Valid values are 'train' and 'test',
+        corresponding to the training set (50,000 examples) and the test
+        set (10,000 examples).
 
     """
     filename = 'mnist.hdf5'
     default_transformers = uint8_pixels_to_floatX(('features',))
 
-    def __init__(self, which_set, **kwargs):
+    def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', True)
-        super(MNIST, self).__init__(self.data_path, which_set, **kwargs)
+        super(MNIST, self).__init__(self.data_path, which_sets, **kwargs)
 
     @property
     def data_path(self):

--- a/fuel/datasets/svhn.py
+++ b/fuel/datasets/svhn.py
@@ -33,20 +33,21 @@ class SVHN(H5PYDataset):
     which_format : {1, 2}
         SVHN format 1 contains the full numbers, whereas SVHN format 2
         contains cropped digits.
-    which_set : {'train', 'test', 'extra'}
-        Whether to load the training set (73,257 examples), the test
-        set (26,032 examples) or the extra set (531,131 examples).
-        Note that SVHN does not have a validation set; usually you
-        will create your own training/validation split
-        using the `subset` argument.
+    which_sets : tuple of str
+        Which split to load. Valid values are 'train', 'test' and 'extra',
+        corresponding to the training set (73,257 examples), the test
+        set (26,032 examples) and the extra set (531,131 examples).
+        Note that SVHN does not have a validation set; usually you will
+        create your own training/validation split using the `subset`
+        argument.
 
     """
     filename = 'svhn_format_{}.hdf5'
     default_transformers = uint8_pixels_to_floatX(('features',))
 
-    def __init__(self, which_format, which_set, **kwargs):
+    def __init__(self, which_format, which_sets, **kwargs):
         self.which_format = which_format
-        super(SVHN, self).__init__(self.data_path, which_set, **kwargs)
+        super(SVHN, self).__init__(self.data_path, which_sets, **kwargs)
 
     @property
     def data_path(self):

--- a/tests/test_binarized_mnist.py
+++ b/tests/test_binarized_mnist.py
@@ -11,7 +11,7 @@ from tests import skip_if_not_available
 def test_binarized_mnist_train():
     skip_if_not_available(datasets=['binarized_mnist.hdf5'])
 
-    dataset = BinarizedMNIST('train', load_in_memory=False)
+    dataset = BinarizedMNIST(('train',), load_in_memory=False)
     handle = dataset.open()
     data, = dataset.get_data(handle, slice(0, 10))
     assert data.dtype == 'uint8'
@@ -24,7 +24,7 @@ def test_binarized_mnist_train():
 def test_binarized_mnist_valid():
     skip_if_not_available(datasets=['binarized_mnist.hdf5'])
 
-    dataset = BinarizedMNIST('valid', load_in_memory=False)
+    dataset = BinarizedMNIST(('valid',), load_in_memory=False)
     handle = dataset.open()
     data, = dataset.get_data(handle, slice(0, 10))
     assert data.dtype == 'uint8'
@@ -37,7 +37,7 @@ def test_binarized_mnist_valid():
 def test_binarized_mnist_test():
     skip_if_not_available(datasets=['binarized_mnist.hdf5'])
 
-    dataset = BinarizedMNIST('test', load_in_memory=False)
+    dataset = BinarizedMNIST(('test',), load_in_memory=False)
     handle = dataset.open()
     data, = dataset.get_data(handle, slice(0, 10))
     assert data.dtype == 'uint8'
@@ -50,15 +50,15 @@ def test_binarized_mnist_test():
 def test_binarized_mnist_axes():
     skip_if_not_available(datasets=['binarized_mnist.hdf5'])
 
-    dataset = BinarizedMNIST('train', load_in_memory=False)
+    dataset = BinarizedMNIST(('train',), load_in_memory=False)
     assert_equal(dataset.axis_labels['features'],
                  ('batch', 'channel', 'height', 'width'))
 
 
 def test_binarized_mnist_invalid_split():
-    assert_raises(ValueError, BinarizedMNIST, 'dummy')
+    assert_raises(ValueError, BinarizedMNIST, ('dummy',))
 
 
 def test_binarized_mnist_data_path():
-    assert BinarizedMNIST('train').data_path == os.path.join(
+    assert BinarizedMNIST(('train',)).data_path == os.path.join(
         config.data_path, 'binarized_mnist.hdf5')

--- a/tests/test_cifar10.py
+++ b/tests/test_cifar10.py
@@ -8,7 +8,7 @@ from fuel.schemes import SequentialScheme
 
 
 def test_cifar10():
-    train = CIFAR10('train', load_in_memory=False)
+    train = CIFAR10(('train',), load_in_memory=False)
     assert train.num_examples == 50000
     handle = train.open()
     features, targets = train.get_data(handle, slice(49990, 50000))
@@ -16,7 +16,7 @@ def test_cifar10():
     assert targets.shape == (10, 1)
     train.close(handle)
 
-    test = CIFAR10('test', load_in_memory=False)
+    test = CIFAR10(('test',), load_in_memory=False)
     handle = test.open()
     features, targets = test.get_data(handle, slice(0, 10))
     assert features.shape == (10, 3, 32, 32)
@@ -31,4 +31,4 @@ def test_cifar10():
     assert data.min() >= 0.0 and data.max() <= 1.0
     assert data.dtype == config.floatX
 
-    assert_raises(ValueError, CIFAR10, 'valid')
+    assert_raises(ValueError, CIFAR10, ('valid',))

--- a/tests/test_cifar100.py
+++ b/tests/test_cifar100.py
@@ -8,7 +8,7 @@ from fuel.schemes import SequentialScheme
 
 
 def test_cifar100():
-    train = CIFAR100('train', load_in_memory=False)
+    train = CIFAR100(('train',), load_in_memory=False)
     assert train.num_examples == 50000
     handle = train.open()
     coarse_labels, features, fine_labels = train.get_data(handle,
@@ -19,7 +19,7 @@ def test_cifar100():
     assert fine_labels.shape == (10, 1)
     train.close(handle)
 
-    test = CIFAR100('test', load_in_memory=False)
+    test = CIFAR100(('test',), load_in_memory=False)
     handle = test.open()
     coarse_labels, features, fine_labels = test.get_data(handle,
                                                          slice(0, 10))
@@ -41,4 +41,4 @@ def test_cifar100():
     assert data.min() >= 0.0 and data.max() <= 1.0
     assert data.dtype == config.floatX
 
-    assert_raises(ValueError, CIFAR100, 'valid')
+    assert_raises(ValueError, CIFAR100, ('valid',))

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -226,6 +226,22 @@ class TestH5PYDataset(object):
         dataset = H5PYDataset(self.h5file, which_set='train')
         assert_raises(ValueError, dataset._out_of_memory_get_data, None, True)
 
+    def test_index_subset_sorted(self):
+        dataset = H5PYDataset(self.h5file, which_set='train', subset=[0, 2, 4])
+        handle = dataset.open()
+        request = slice(0, 3)
+        assert_equal(dataset.get_data(handle, request),
+                     (self.features[[0, 2, 4]], self.targets[[0, 2, 4]]))
+        dataset.close(handle)
+
+    def test_index_subset_unsorted(self):
+        dataset = H5PYDataset(self.h5file, which_set='train', subset=[0, 4, 2])
+        handle = dataset.open()
+        request = slice(0, 3)
+        assert_equal(dataset.get_data(handle, request),
+                     (self.features[[0, 4, 2]], self.targets[[0, 4, 2]]))
+        dataset.close(handle)
+
     def test_vlen_axis_labels(self):
         dataset = H5PYDataset(self.vlen_h5file, which_set='train')
         assert_equal(dataset.axis_labels['features'],

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -107,15 +107,15 @@ class TestH5PYDataset(object):
         self.h5file.close()
         self.vlen_h5file.close()
 
-    def test_raises_value_error_when_which_set_is_string(self):
+    def test_raises_value_error_when_which_sets_is_string(self):
         assert_raises(ValueError, H5PYDataset, self.h5file, 'train')
 
     def test_split_parsing(self):
-        train_set = H5PYDataset(self.h5file, which_set=('train',))
+        train_set = H5PYDataset(self.h5file, which_sets=('train',))
         assert train_set.provides_sources == ('features', 'targets')
-        test_set = H5PYDataset(self.h5file, which_set=('test',))
+        test_set = H5PYDataset(self.h5file, which_sets=('test',))
         assert test_set.provides_sources == ('features', 'targets')
-        unlabeled_set = H5PYDataset(self.h5file, which_set=('unlabeled',))
+        unlabeled_set = H5PYDataset(self.h5file, which_sets=('unlabeled',))
         assert unlabeled_set.provides_sources == ('features',)
 
     def test_get_all_splits(self):
@@ -140,7 +140,7 @@ class TestH5PYDataset(object):
                      [0, 5, 2])
 
     def test_axis_labels(self):
-        dataset = H5PYDataset(self.h5file, which_set=('train',))
+        dataset = H5PYDataset(self.h5file, which_sets=('train',))
         assert dataset.axis_labels == {'features': ('batch', 'feature'),
                                        'targets': ('batch', 'index')}
 
@@ -152,19 +152,19 @@ class TestH5PYDataset(object):
             split_dict = {'train': {'features': (0, 10, None, '.')}}
             h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
             dataset = cPickle.loads(
-                cPickle.dumps(H5PYDataset(h5file, which_set=('train',))))
+                cPickle.dumps(H5PYDataset(h5file, which_sets=('train',))))
             assert dataset.data_sources is None
         finally:
             os.remove('file.hdf5')
 
     def test_data_stream_pickling(self):
-        stream = DataStream(H5PYDataset(self.h5file, which_set=('train',)))
+        stream = DataStream(H5PYDataset(self.h5file, which_sets=('train',)))
         cPickle.loads(cPickle.dumps(stream))
         stream.close()
 
     def test_multiple_instances(self):
-        dataset_1 = H5PYDataset(self.h5file, which_set=('train',))
-        dataset_2 = H5PYDataset(self.h5file, which_set=('train',))
+        dataset_1 = H5PYDataset(self.h5file, which_sets=('train',))
+        dataset_2 = H5PYDataset(self.h5file, which_sets=('train',))
         handle_1 = dataset_1.open()
         handle_2 = dataset_2.open()
         dataset_1.get_data(state=handle_1, request=slice(0, 10))
@@ -173,8 +173,8 @@ class TestH5PYDataset(object):
         dataset_2.close(handle_2)
 
     def test_single_split(self):
-        train_set = H5PYDataset(self.h5file, which_set=('train',))
-        test_set = H5PYDataset(self.h5file, which_set=('test',))
+        train_set = H5PYDataset(self.h5file, which_sets=('train',))
+        test_set = H5PYDataset(self.h5file, which_sets=('test',))
         train_handle = train_set.open()
         test_handle = test_set.open()
         assert_equal(train_set.get_data(train_handle, slice(0, 8)),
@@ -185,7 +185,7 @@ class TestH5PYDataset(object):
         test_set.close(test_handle)
 
     def test_multiple_split(self):
-        dataset = H5PYDataset(self.h5file, which_set=('train', 'test'))
+        dataset = H5PYDataset(self.h5file, which_sets=('train', 'test'))
         handle = dataset.open()
         assert_equal(dataset.get_data(handle, slice(0, 30)),
                      (self.features[:30], self.targets[:30]))
@@ -193,7 +193,7 @@ class TestH5PYDataset(object):
 
     def test_out_of_memory(self):
         dataset = H5PYDataset(
-            self.h5file, which_set=('test',), load_in_memory=False)
+            self.h5file, which_sets=('test',), load_in_memory=False)
         handle = dataset.open()
         assert_equal(dataset.get_data(handle, slice(3, 5)),
                      (self.features[23:25], self.targets[23:25]))
@@ -201,7 +201,7 @@ class TestH5PYDataset(object):
 
     def test_in_memory(self):
         dataset = H5PYDataset(
-            self.h5file, which_set=('train',), load_in_memory=True)
+            self.h5file, which_sets=('train',), load_in_memory=True)
         handle = dataset.open()
         request = slice(0, 10)
         assert_equal(dataset.get_data(handle, request),
@@ -210,7 +210,7 @@ class TestH5PYDataset(object):
 
     def test_out_of_memory_sorted_indices(self):
         dataset = H5PYDataset(
-            self.h5file, which_set=('train',), load_in_memory=False,
+            self.h5file, which_sets=('train',), load_in_memory=False,
             sort_indices=True)
         handle = dataset.open()
         request = [7, 4, 6, 2, 5]
@@ -220,7 +220,7 @@ class TestH5PYDataset(object):
 
     def test_out_of_memory_unsorted_indices(self):
         dataset = H5PYDataset(
-            self.h5file, which_set=('train',), load_in_memory=False,
+            self.h5file, which_sets=('train',), load_in_memory=False,
             sort_indices=False)
         handle = dataset.open()
         assert_raises(TypeError, dataset.get_data, handle, [7, 4, 6, 2, 5])
@@ -229,12 +229,12 @@ class TestH5PYDataset(object):
     def test_value_error_on_subset_step_gt_1(self):
         def instantiate_h5py_dataset():
             return H5PYDataset(
-                self.h5file, which_set=('train',), subset=slice(0, 10, 2))
+                self.h5file, which_sets=('train',), subset=slice(0, 10, 2))
         assert_raises(ValueError, instantiate_h5py_dataset)
 
     def test_value_error_on_unequal_sources(self):
         def get_subsets():
-            return H5PYDataset(self.h5file, which_set=('train',)).subsets
+            return H5PYDataset(self.h5file, which_sets=('train',)).subsets
         split_dict = {'train': {'features': (0, 20), 'targets': (0, 15)},
                       'test': {'features': (20, 30), 'targets': (20, 30)},
                       'unlabeled': {'features': (30, 100, None, '.')}}
@@ -243,18 +243,18 @@ class TestH5PYDataset(object):
 
     def test_io_error_on_unopened_file_handle(self):
         def get_file_handle():
-            dataset = H5PYDataset(self.h5file, which_set=('train',))
+            dataset = H5PYDataset(self.h5file, which_sets=('train',))
             dataset._external_file_handle = None
             return dataset._file_handle
         assert_raises(IOError, get_file_handle)
 
     def test_value_error_in_memory_get_data(self):
-        dataset = H5PYDataset(self.h5file, which_set=('train',))
+        dataset = H5PYDataset(self.h5file, which_sets=('train',))
         assert_raises(ValueError, dataset._in_memory_get_data, None, None)
         assert_raises(ValueError, dataset._in_memory_get_data, True, None)
 
     def test_value_error_out_of_memory_get_data(self):
-        dataset = H5PYDataset(self.h5file, which_set=('train',))
+        dataset = H5PYDataset(self.h5file, which_sets=('train',))
         assert_raises(ValueError, dataset._out_of_memory_get_data, None, True)
 
     def test_index_split_out_of_memory(self):
@@ -272,7 +272,7 @@ class TestH5PYDataset(object):
                       'test': {'features': (-1, -1, test_ref, '')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         dataset = H5PYDataset(
-            h5file, which_set=('train',), load_in_memory=False)
+            h5file, which_sets=('train',), load_in_memory=False)
         handle = dataset.open()
         request = slice(0, 5)
         assert_equal(
@@ -295,7 +295,7 @@ class TestH5PYDataset(object):
                       'test': {'features': (-1, -1, test_ref, '')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         dataset = H5PYDataset(
-            h5file, which_set=('train',), load_in_memory=True)
+            h5file, which_sets=('train',), load_in_memory=True)
         handle = dataset.open()
         request = slice(0, 5)
         assert_equal(
@@ -305,7 +305,7 @@ class TestH5PYDataset(object):
 
     def test_index_subset_sorted(self):
         dataset = H5PYDataset(
-            self.h5file, which_set=('train',), subset=[0, 2, 4])
+            self.h5file, which_sets=('train',), subset=[0, 2, 4])
         handle = dataset.open()
         request = slice(0, 3)
         assert_equal(dataset.get_data(handle, request),
@@ -314,7 +314,7 @@ class TestH5PYDataset(object):
 
     def test_index_subset_unsorted(self):
         dataset = H5PYDataset(
-            self.h5file, which_set=('train',), subset=[0, 4, 2])
+            self.h5file, which_sets=('train',), subset=[0, 4, 2])
         handle = dataset.open()
         request = slice(0, 3)
         assert_equal(dataset.get_data(handle, request),
@@ -322,7 +322,7 @@ class TestH5PYDataset(object):
         dataset.close(handle)
 
     def test_vlen_axis_labels(self):
-        dataset = H5PYDataset(self.vlen_h5file, which_set=('train',))
+        dataset = H5PYDataset(self.vlen_h5file, which_sets=('train',))
         assert_equal(dataset.axis_labels['features'],
                      ('batch', 'channel', 'height', 'width'))
         assert_equal(dataset.axis_labels['targets'], ('batch', 'index'))
@@ -337,7 +337,7 @@ class TestH5PYDataset(object):
 
     def test_vlen_reshape_in_memory(self):
         dataset = H5PYDataset(
-            self.vlen_h5file, which_set=('train',), subset=slice(1, 3),
+            self.vlen_h5file, which_sets=('train',), subset=slice(1, 3),
             load_in_memory=True)
         expected_features = numpy.empty((2,), dtype=numpy.object)
         for i, f in enumerate(self.vlen_features[1:3]):
@@ -352,7 +352,7 @@ class TestH5PYDataset(object):
 
     def test_vlen_reshape_out_of_memory(self):
         dataset = H5PYDataset(
-            self.vlen_h5file, which_set=('train',), subset=slice(1, 3),
+            self.vlen_h5file, which_sets=('train',), subset=slice(1, 3),
             load_in_memory=False)
         expected_features = numpy.empty((2,), dtype=numpy.object)
         for i, f in enumerate(self.vlen_features[1:3]):
@@ -367,7 +367,7 @@ class TestH5PYDataset(object):
 
     def test_vlen_reshape_out_of_memory_unordered(self):
         dataset = H5PYDataset(
-            self.vlen_h5file, which_set=('train',), load_in_memory=False)
+            self.vlen_h5file, which_sets=('train',), load_in_memory=False)
         expected_features = numpy.empty((4,), dtype=numpy.object)
         for i, j in enumerate([0, 3, 1, 2]):
             expected_features[i] = self.vlen_features[j]
@@ -381,7 +381,7 @@ class TestH5PYDataset(object):
 
     def test_vlen_reshape_out_of_memory_unordered_no_check(self):
         dataset = H5PYDataset(
-            self.vlen_h5file, which_set=('train',), load_in_memory=False,
+            self.vlen_h5file, which_sets=('train',), load_in_memory=False,
             sort_indices=False)
         expected_features = numpy.empty((4,), dtype=numpy.object)
         for i, j in enumerate([0, 1, 2, 3]):

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -235,8 +235,10 @@ class TestH5PYDataset(object):
         h5file['features'].dims[1].label = 'feature'
         h5file['train_features_subset'] = numpy.arange(0, 10, 2)
         h5file['test_features_subset'] = numpy.arange(1, 10, 2)
-        h5file['features'].attrs['train_subset'] = h5file['train_features_subset'].ref
-        h5file['features'].attrs['test_subset'] = h5file['test_features_subset'].ref
+        h5file['features'].attrs['train_subset'] = h5file[
+            'train_features_subset'].ref
+        h5file['features'].attrs['test_subset'] = h5file[
+            'test_features_subset'].ref
         split_dict = {'train': {'features': (-1, -1, '.')},
                       'test': {'features': (-1, -1, '')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
@@ -256,8 +258,10 @@ class TestH5PYDataset(object):
         h5file['features'].dims[1].label = 'feature'
         h5file['train_features_subset'] = numpy.arange(0, 10, 2)
         h5file['test_features_subset'] = numpy.arange(1, 10, 2)
-        h5file['features'].attrs['train_subset'] = h5file['train_features_subset'].ref
-        h5file['features'].attrs['test_subset'] = h5file['test_features_subset'].ref
+        h5file['features'].attrs['train_subset'] = h5file[
+            'train_features_subset'].ref
+        h5file['features'].attrs['test_subset'] = h5file[
+            'test_features_subset'].ref
         split_dict = {'train': {'features': (-1, -1, '.')},
                       'test': {'features': (-1, -1, '')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -115,6 +115,27 @@ class TestH5PYDataset(object):
         unlabeled_set = H5PYDataset(self.h5file, which_set='unlabeled')
         assert unlabeled_set.provides_sources == ('features',)
 
+    def test_get_all_splits(self):
+        splits = ('train', 'test', 'unlabeled')
+        available_splits = H5PYDataset.get_all_splits(self.h5file)
+        assert (all(split in available_splits for split in splits) and
+                all(split in splits for split in available_splits))
+
+    def test_get_all_sources(self):
+        sources = ('features', 'targets')
+        all_sources = H5PYDataset.get_all_sources(self.h5file)
+        assert (all(source in all_sources for source in sources) and
+                all(source in sources for source in all_sources))
+
+    def test_unsorted_fancy_index_1(self):
+        indexable = numpy.arange(10)
+        assert_equal(H5PYDataset.unsorted_fancy_index([0], indexable), [0])
+
+    def test_unsorted_fancy_index_gt_1(self):
+        indexable = numpy.arange(10)
+        assert_equal(H5PYDataset.unsorted_fancy_index([0, 5, 2], indexable),
+                     [0, 5, 2])
+
     def test_axis_labels(self):
         dataset = H5PYDataset(self.h5file, which_set='train')
         assert dataset.axis_labels == {'features': ('batch', 'feature'),
@@ -245,6 +266,7 @@ class TestH5PYDataset(object):
         request = slice(0, 5)
         assert_equal(
             dataset.get_data(handle, request)[0], features[0:10:2])
+        assert_equal(dataset.num_examples, 5)
         dataset.close(handle)
 
     def test_index_split_in_memory(self):
@@ -266,6 +288,7 @@ class TestH5PYDataset(object):
         request = slice(0, 5)
         assert_equal(
             dataset.get_data(handle, request)[0], features[0:10:2])
+        assert_equal(dataset.num_examples, 5)
         dataset.close(handle)
 
     def test_index_subset_sorted(self):

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -169,7 +169,7 @@ class TestH5PYDataset(object):
         dataset_1.close(handle_1)
         dataset_2.close(handle_2)
 
-    def test_split(self):
+    def test_single_split(self):
         train_set = H5PYDataset(self.h5file, which_set='train')
         test_set = H5PYDataset(self.h5file, which_set='test')
         train_handle = train_set.open()
@@ -180,6 +180,13 @@ class TestH5PYDataset(object):
                      (self.features[20:22], self.targets[20:22]))
         train_set.close(train_handle)
         test_set.close(test_handle)
+
+    def test_multiple_split(self):
+        dataset = H5PYDataset(self.h5file, which_set=('train', 'test'))
+        handle = dataset.open()
+        assert_equal(dataset.get_data(handle, slice(0, 30)),
+                     (self.features[:30], self.targets[:30]))
+        dataset.close(handle)
 
     def test_out_of_memory(self):
         dataset = H5PYDataset(

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -64,9 +64,9 @@ class TestH5PYDataset(object):
         h5file['targets'] = self.targets
         h5file['targets'].dims[0].label = 'batch'
         h5file['targets'].dims[1].label = 'index'
-        split_dict = {'train': {'features': (0, 20, '.'), 'targets': (0, 20)},
-                      'test': {'features': (20, 30, ''), 'targets': (20, 30)},
-                      'unlabeled': {'features': (30, 100)}}
+        split_dict = {'train': {'features': (0, 20, None), 'targets': (0, 20)},
+                      'test': {'features': (20, 30), 'targets': (20, 30)},
+                      'unlabeled': {'features': (30, 100, None, '.')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         self.h5file = h5file
 
@@ -125,7 +125,7 @@ class TestH5PYDataset(object):
             features = numpy.arange(360, dtype='uint16').reshape((10, 36))
             h5file = h5py.File('file.hdf5', mode='w')
             h5file['features'] = features
-            split_dict = {'train': {'features': (0, 10, '.')}}
+            split_dict = {'train': {'features': (0, 10, None, '.')}}
             h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
             dataset = cPickle.loads(
                 cPickle.dumps(H5PYDataset(h5file, which_set='train')))
@@ -204,9 +204,9 @@ class TestH5PYDataset(object):
     def test_value_error_on_unequal_sources(self):
         def get_subsets():
             return H5PYDataset(self.h5file, which_set='train').subsets
-        split_dict = {'train': {'features': (0, 20, '.'), 'targets': (0, 15)},
-                      'test': {'features': (20, 30, ''), 'targets': (20, 30)},
-                      'unlabeled': {'features': (30, 100)}}
+        split_dict = {'train': {'features': (0, 20), 'targets': (0, 15)},
+                      'test': {'features': (20, 30), 'targets': (20, 30)},
+                      'unlabeled': {'features': (30, 100, None, '.')}}
         self.h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         assert_raises(ValueError, get_subsets)
 
@@ -235,12 +235,10 @@ class TestH5PYDataset(object):
         h5file['features'].dims[1].label = 'feature'
         h5file['train_features_subset'] = numpy.arange(0, 10, 2)
         h5file['test_features_subset'] = numpy.arange(1, 10, 2)
-        h5file['features'].attrs['train_subset'] = h5file[
-            'train_features_subset'].ref
-        h5file['features'].attrs['test_subset'] = h5file[
-            'test_features_subset'].ref
-        split_dict = {'train': {'features': (-1, -1, '.')},
-                      'test': {'features': (-1, -1, '')}}
+        train_ref = h5file['train_features_subset'].ref
+        test_ref = h5file['test_features_subset'].ref
+        split_dict = {'train': {'features': (-1, -1, train_ref, '.')},
+                      'test': {'features': (-1, -1, test_ref, '')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         dataset = H5PYDataset(h5file, which_set='train', load_in_memory=False)
         handle = dataset.open()
@@ -258,12 +256,10 @@ class TestH5PYDataset(object):
         h5file['features'].dims[1].label = 'feature'
         h5file['train_features_subset'] = numpy.arange(0, 10, 2)
         h5file['test_features_subset'] = numpy.arange(1, 10, 2)
-        h5file['features'].attrs['train_subset'] = h5file[
-            'train_features_subset'].ref
-        h5file['features'].attrs['test_subset'] = h5file[
-            'test_features_subset'].ref
-        split_dict = {'train': {'features': (-1, -1, '.')},
-                      'test': {'features': (-1, -1, '')}}
+        train_ref = h5file['train_features_subset'].ref
+        test_ref = h5file['test_features_subset'].ref
+        split_dict = {'train': {'features': (-1, -1, train_ref, '.')},
+                      'test': {'features': (-1, -1, test_ref, '')}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         dataset = H5PYDataset(h5file, which_set='train', load_in_memory=True)
         handle = dataset.open()

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -226,11 +226,14 @@ class TestH5PYDataset(object):
         assert_raises(TypeError, dataset.get_data, handle, [7, 4, 6, 2, 5])
         dataset.close(handle)
 
-    def test_value_error_on_subset_step_gt_1(self):
-        def instantiate_h5py_dataset():
-            return H5PYDataset(
-                self.h5file, which_sets=('train',), subset=slice(0, 10, 2))
-        assert_raises(ValueError, instantiate_h5py_dataset)
+    def test_subset_step_gt_1(self):
+        dataset = H5PYDataset(
+            self.h5file, which_sets=('train',), subset=slice(0, 10, 2))
+        handle = dataset.open()
+        assert_equal(dataset.get_data(handle, [0, 1, 2, 3, 4]),
+                     (self.features[slice(0, 10, 2)],
+                      self.targets[slice(0, 10, 2)]))
+        dataset.close(handle)
 
     def test_value_error_on_unequal_sources(self):
         def get_subsets():

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -14,7 +14,7 @@ from tests import skip_if_not_available
 def test_mnist_train():
     skip_if_not_available(datasets=['mnist.hdf5'])
 
-    dataset = MNIST('train', load_in_memory=False)
+    dataset = MNIST(('train',), load_in_memory=False)
     handle = dataset.open()
     data, labels = dataset.get_data(handle, slice(0, 10))
     assert data.dtype == 'uint8'
@@ -38,7 +38,7 @@ def test_mnist_train():
 def test_mnist_test():
     skip_if_not_available(datasets=['mnist.hdf5'])
 
-    dataset = MNIST('test', load_in_memory=False)
+    dataset = MNIST(('test',), load_in_memory=False)
     handle = dataset.open()
     data, labels = dataset.get_data(handle, slice(0, 10))
     assert data.dtype == 'uint8'
@@ -61,7 +61,7 @@ def test_mnist_test():
 def test_mnist_axes():
     skip_if_not_available(datasets=['mnist.hdf5'])
 
-    dataset = MNIST('train', load_in_memory=False)
+    dataset = MNIST(('train',), load_in_memory=False)
     assert_equal(dataset.axis_labels['features'],
                  ('batch', 'channel', 'height', 'width'))
 
@@ -69,11 +69,11 @@ def test_mnist_axes():
 def test_mnist_invalid_split():
     skip_if_not_available(datasets=['mnist.hdf5'])
 
-    assert_raises(ValueError, MNIST, 'dummy')
+    assert_raises(ValueError, MNIST, ('dummy',))
 
 
 def test_mnist_data_path():
     skip_if_not_available(datasets=['mnist.hdf5'])
 
-    assert MNIST('train').data_path == os.path.join(config.data_path,
-                                                    'mnist.hdf5')
+    assert MNIST(('train',)).data_path == os.path.join(config.data_path,
+                                                       'mnist.hdf5')

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -13,7 +13,7 @@ from tests import skip_if_not_available
 def test_in_memory():
     skip_if_not_available(datasets=['mnist.hdf5'])
     # Load MNIST and get two batches
-    mnist = MNIST('train', load_in_memory=True)
+    mnist = MNIST(('train',), load_in_memory=True)
     data_stream = DataStream(mnist, iteration_scheme=SequentialScheme(
         examples=mnist.num_examples, batch_size=256))
     epoch = data_stream.get_epoch_iterator()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,7 +11,7 @@ from fuel.streams import DataStream, ServerDataStream
 
 def get_stream():
     return DataStream(
-        MNIST('train'), iteration_scheme=SequentialScheme(1500, 500))
+        MNIST(('train',)), iteration_scheme=SequentialScheme(1500, 500))
 
 
 class TestServer(object):

--- a/tests/test_svhn.py
+++ b/tests/test_svhn.py
@@ -15,8 +15,8 @@ def test_svhn():
         f = h5py.File('svhn_format_2.hdf5', 'w')
         f['features'] = numpy.arange(100, dtype='uint8').reshape((10, 10))
         f['targets'] = numpy.arange(10, dtype='uint8').reshape((10, 1))
-        split_dict = {'train': {'features': (0, 8, '.'), 'targets': (0, 8)},
-                      'test': {'features': (8, 10, ''), 'targets': (8, 10)}}
+        split_dict = {'train': {'features': (0, 8), 'targets': (0, 8)},
+                      'test': {'features': (8, 10), 'targets': (8, 10)}}
         f.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         f.close()
         dataset = SVHN(which_format=2, which_set='train')

--- a/tests/test_svhn.py
+++ b/tests/test_svhn.py
@@ -19,7 +19,7 @@ def test_svhn():
                       'test': {'features': (8, 10), 'targets': (8, 10)}}
         f.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         f.close()
-        dataset = SVHN(which_format=2, which_set=('train',))
+        dataset = SVHN(which_format=2, which_sets=('train',))
         assert_equal(dataset.data_path,
                      os.path.join(config.data_path, 'svhn_format_2.hdf5'))
     finally:

--- a/tests/test_svhn.py
+++ b/tests/test_svhn.py
@@ -19,7 +19,7 @@ def test_svhn():
                       'test': {'features': (8, 10), 'targets': (8, 10)}}
         f.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         f.close()
-        dataset = SVHN(which_format=2, which_set='train')
+        dataset = SVHN(which_format=2, which_set=('train',))
         assert_equal(dataset.data_path,
                      os.path.join(config.data_path, 'svhn_format_2.hdf5'))
     finally:


### PR DESCRIPTION
Fixes #101. Fixes #102.

This PR adds support for two types of index subsets:
* At the HDF5 level, it allows the user to specify a split as a list of indices.
* At the dataset level, it allows the user to specify a subset of a split as a list of indices.

The current implementation is a draft. In particular, I had to do some pretty ugly things to the H5PYDataset interface in order to support HDF5-level index split. Basically, if `start` and `stop` are negative, H5PYDataset will look for a `split_subset` attribute in the sources (where `split` is the name of the split), which is a reference to an HDF5 dataset that contains the indices for that split/source pair.

There are two things I'd like to polish before I feel like this PR is ready to be merged:
* I think it's time to rethink the H5PYDataset interface to integrate HDF5-level index splits in a less hacky way.
* I'd like to document the interface itself in the online docs.

@rizar I think this might interest you.