### PR TITLE
Improve IndexableDataset with non-ndarray sources.

### DIFF
--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -1,5 +1,7 @@
 import collections
 from abc import ABCMeta, abstractmethod
+
+import numpy
 from six import add_metaclass
 
 from picklable_itertools import iter_, izip
@@ -340,4 +342,13 @@ class IndexableDataset(Dataset):
     def get_data(self, state=None, request=None):
         if state is not None or request is None:
             raise ValueError
-        return tuple(indexable[request] for indexable in self.indexables)
+        if isinstance(request, collections.Iterable):
+            returned = []
+            for indexable in self.indexables:
+                if isinstance(indexable, numpy.ndarray):
+                    returned.append(indexable[request])
+                else:
+                    returned.append([indexable[r] for r in request])
+            return tuple(returned)
+        else:
+            return tuple(indexable[request] for indexable in self.indexables)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -7,7 +7,7 @@ from six.moves import zip, range
 
 from fuel.datasets import Dataset, IterableDataset, IndexableDataset
 from fuel.streams import DataStream
-from fuel.schemes import BatchSizeScheme, ConstantScheme
+from fuel.schemes import ShuffledScheme, BatchSizeScheme, ConstantScheme
 from fuel.transformers import Mapping
 
 
@@ -116,6 +116,18 @@ class TestIndexableDataset(object):
     def test_value_error_get_data_none_request(self):
         assert_raises(
             ValueError, IndexableDataset([1, 2, 3]).get_data, None, None)
+
+    def test_batch_iteration_scheme_with_lists(self):
+        """Batch schemes should work with more than ndarrays."""
+        data = IndexableDataset(OrderedDict([('foo', list(range(50))),
+                                             ('bar', list(range(1, 51)))]))
+        stream = DataStream(data,
+                            iteration_scheme=ShuffledScheme(data.num_examples,
+                                                            5))
+        returned = [sum(batches, []) for batches in
+                    zip(*list(stream.get_epoch_iterator()))]
+        assert set(returned[0]) == set(range(50))
+        assert set(returned[1]) == set(range(1, 51))
 
 
 def test_sources_selection():


### PR DESCRIPTION
If the request is an instance of ~~collections.Container~~ collections.Iterable but not a numpy.ndarray, do not attempt to do fancy indexing; instead, perform the indexing in a loop. This allows one to use an IndexableDataset with list sources in conjunction with a BatchScheme.