### PR TITLE
Reshape the targets of CIFAR10 

### DIFF
--- a/fuel/converters/cifar10.py
+++ b/fuel/converters/cifar10.py
@@ -54,6 +54,7 @@ def convert_cifar10(directory, output_file):
     train_labels = numpy.concatenate(
         [numpy.array(batch['labels'], dtype=numpy.uint8)
             for batch in train_batches])
+    train_labels = numpy.expand_dims(train_labels, 1)
 
     file = tar_file.extractfile('cifar-10-batches-py/test_batch')
     try:
@@ -67,6 +68,7 @@ def convert_cifar10(directory, output_file):
     test_features = test['data'].reshape(test['data'].shape[0],
                                          3, 32, 32)
     test_labels = numpy.array(test['labels'], dtype=numpy.uint8)
+    test_labels = numpy.expand_dims(test_labels, 1)
 
     data = (('train', 'features', train_features),
             ('train', 'targets', train_labels),
@@ -78,6 +80,7 @@ def convert_cifar10(directory, output_file):
     h5file['features'].dims[2].label = 'height'
     h5file['features'].dims[3].label = 'width'
     h5file['targets'].dims[0].label = 'batch'
+    h5file['targets'].dims[1].label = 'index'
 
     h5file.flush()
     h5file.close()

--- a/tests/test_cifar10.py
+++ b/tests/test_cifar10.py
@@ -13,14 +13,14 @@ def test_cifar10():
     handle = train.open()
     features, targets = train.get_data(handle, slice(49990, 50000))
     assert features.shape == (10, 3, 32, 32)
-    assert targets.shape == (10,)
+    assert targets.shape == (10, 1)
     train.close(handle)
 
     test = CIFAR10('test', load_in_memory=False)
     handle = test.open()
     features, targets = test.get_data(handle, slice(0, 10))
     assert features.shape == (10, 3, 32, 32)
-    assert targets.shape == (10,)
+    assert targets.shape == (10, 1)
     assert features.dtype == numpy.uint8
     assert targets.dtype == numpy.uint8
     test.close(handle)


### PR DESCRIPTION
For the MNIST, the `fuel-convert` generates targets as 2D array and it can work well with Blocks.
But for the CIFAR10, the shape of the arrays of targets is `(num_examples, )` which is 1D array, and it seems inconsistent with Blocks.
The dimension was originally 2D (in both implementation and test), and at #98 it was modified as 1D.