### PR TITLE
Add stream ability to select subset of data sources

### DIFF
--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -149,7 +149,7 @@ class Dataset(object):
         pass
 
     @abstractmethod
-    def get_data(self, state=None, request=None):
+    def get_data(self, state=None, request=None, sources=None):
         """Request data from the dataset.
 
         .. todo::
@@ -273,10 +273,16 @@ class IterableDataset(Dataset):
         iterators = [iter_(channel) for channel in self.iterables]
         return izip(*iterators)
 
-    def get_data(self, state=None, request=None):
+    def get_data(self, state=None, request=None, sources=None):
         if state is None or request is not None:
             raise ValueError
-        return next(state)
+
+        data = next(state)
+
+        if sources:
+            data = [data[self.sources.index(source)] for source in sources]
+
+        return data
 
 
 class IndexableDataset(Dataset):
@@ -339,7 +345,7 @@ class IndexableDataset(Dataset):
     def num_examples(self):
         return len(self.indexables[0])
 
-    def get_data(self, state=None, request=None):
+    def get_data(self, state=None, request=None, sources=None):
         if state is not None or request is None:
             raise ValueError
         if isinstance(request, collections.Iterable):

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -68,7 +68,7 @@ class PytablesDataset(Dataset):
         del self._h5file
         del self._nodes
 
-    def get_data(self, state=None, request=None):
+    def get_data(self, state=None, request=None, sources=None):
         """ Returns data from HDF5 dataset.
 
         .. note:: The best performance if `request` is a slice.
@@ -83,6 +83,10 @@ class PytablesDataset(Dataset):
             data = [node[request, ...] for node in self.nodes]
         else:
             raise ValueError
+
+        if sources:
+            data = [data[self.sources.index(source)] for source in sources]
+
         return data
 
 
@@ -391,7 +395,7 @@ class H5PYDataset(Dataset):
         else:
             raise IOError('no open handle for file {}'.format(self.path))
 
-    def get_data(self, state=None, request=None):
+    def get_data(self, state=None, request=None, sources=None):
         if self.load_in_memory:
             data, shapes = self._in_memory_get_data(state, request)
         else:
@@ -400,6 +404,10 @@ class H5PYDataset(Dataset):
             if shapes[i] is not None:
                 for j in range(len(data[i])):
                     data[i][j] = data[i][j].reshape(shapes[i][j])
+
+        if sources:
+            data = [data[self.sources.index(source)] for source in sources]
+
         return tuple(data)
 
     def _in_memory_get_data(self, state=None, request=None):

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -97,8 +97,9 @@ class DataStream(AbstractDataStream):
         The dataset from which the data is fetched.
 
     """
-    def __init__(self, dataset, **kwargs):
+    def __init__(self, dataset, sources=None, **kwargs):
         kwargs.setdefault('axis_labels', dataset.axis_labels)
+        self.sources = sources
         super(DataStream, self).__init__(**kwargs)
         self.dataset = dataset
         self.data_state = self.dataset.open()
@@ -106,7 +107,7 @@ class DataStream(AbstractDataStream):
 
     @property
     def sources(self):
-        if hasattr(self, '_sources'):
+        if getattr(self, '_sources', None):
             return self._sources
         return self.dataset.sources
 
@@ -126,7 +127,7 @@ class DataStream(AbstractDataStream):
 
     def get_data(self, request=None):
         """Get data from the dataset."""
-        return self.dataset.get_data(self.data_state, request)
+        return self.dataset.get_data(self.data_state, request, self.sources)
 
     def get_epoch_iterator(self, **kwargs):
         """Get an epoch iterator for the data stream."""

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,3 +1,5 @@
+import unittest
+
 import numpy
 from numpy.testing import assert_equal
 
@@ -5,14 +7,24 @@ from fuel.datasets import IterableDataset
 from fuel.streams import DataStream
 
 
-class TestDataStream(object):
+class TestDataStream(unittest.TestCase):
     def setUp(self):
-        self.dataset = IterableDataset(numpy.eye(2))
+        self.dataset = IterableDataset(dict(data=numpy.eye(2),
+                                            targets=numpy.arange(2)))
 
     def test_sources_setter(self):
         stream = DataStream(self.dataset)
         stream.sources = ('features',)
         assert_equal(stream.sources, ('features',))
+
+    def test_sources_selection(self):
+        stream = DataStream(self.dataset, sources=('data',))
+        assert len(stream.get_epoch_iterator().next()) == 1
+        stream = DataStream(self.dataset, sources=('data', 'targets'))
+        assert len(stream.get_epoch_iterator().next()) == 2
+        stream = DataStream(self.dataset, sources=('data', 'targets', 'error'))
+        self.assertRaises(ValueError,
+                          lambda: stream.get_epoch_iterator().next())
 
     def test_no_axis_labels(self):
         stream = DataStream(self.dataset)


### PR DESCRIPTION
If I understand correctly, we need to modify dataset object in order to get different subset of sources without having to reload all data. 

The idea is not to force dataset to load all provided sources and move sources selection to stream but rather add a stream ability to select subset of sources. This would be useful in cases where we manipulate a single dataset object for different training settings, e.g. unsupervised training followed by supervised training.