### PR TITLE
Upgrade Fuel's handling of data path

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,9 @@ or by setting the environment variable ``FUEL_DATA_PATH``
 
    export FUEL_DATA_PATH=/home/your_data
 
+This data path is a sequence of paths separated by an os-specific delimiter
+(':' for Linux and OSX, ';' for Windows).
+
 For example, after downloading the MNIST data to ``/home/your_data/mnist`` we
 construct a handle to the data.
 

--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -204,22 +204,18 @@ amount of code to write is very minimal:
 
 .. code-block:: python
 
-    import os
-
-    from fuel import config
     from fuel.datasets import H5PYDataset
+    from fuel.utils import find_in_data_path
 
 
     class Iris(H5PYDataset):
         filename = 'iris.hdf5'
 
-        def __init__(self, which_set, **kwargs):
+        def __init__(self, which_sets=which_sets, **kwargs):
             kwargs.setdefault('load_in_memory', True)
-            super(Iris, self).__init__(self.data_path, which_set, **kwargs)
-
-        @property
-        def data_path(self):
-            return os.path.join(config.data_path, self.filename)
+            super(Iris, self).__init__(
+                file_or_path=find_in_data_path(self.filename),
+                which_sets=which_sets, **kwargs)
 
 Our subclass is just a thin wrapper around the
 :class:`~.datasets.hdf5.H5PYDataset` class that defines the data path and
@@ -344,9 +340,9 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     >>> from fuel import config
     >>> from fuel.datasets import H5PYDataset
     >>> class Iris(H5PYDataset):
-    ...    def __init__(self, which_set, **kwargs):
+    ...    def __init__(self, which_sets, **kwargs):
     ...        kwargs.setdefault('load_in_memory', True)
-    ...        super(Iris, self).__init__('iris.hdf5', which_set, **kwargs)
+    ...        super(Iris, self).__init__('iris.hdf5', which_sets, **kwargs)
 
 .. doctest::
 

--- a/fuel/config_parser.py
+++ b/fuel/config_parser.py
@@ -18,6 +18,9 @@ Which could be overwritten by using environment variables:
 
    $ FUEL_DATA_PATH=/home/users/other_datasets python
 
+This data path is a sequence of paths separated by an os-specific
+delimiter (':' for Linux and OSX, ';' for Windows).
+
 If a setting is not configured and does not provide a default, a
 :class:`~.ConfigurationError` is raised when it is
 accessed.
@@ -34,7 +37,9 @@ The following configurations are supported:
 .. option:: data_path
 
    The path where dataset files are stored. Can also be set using the
-   environment variable ``FUEL_DATA_PATH``.
+   environment variable ``FUEL_DATA_PATH``. Expected to be a sequence
+   of paths separated by an os-specific delimiter (':' for Linux and
+   OSX, ';' for Windows).
 
 
 .. todo::

--- a/fuel/datasets/billion.py
+++ b/fuel/datasets/billion.py
@@ -1,7 +1,7 @@
 import os
 
-from fuel import config
 from fuel.datasets import TextFile
+from fuel.utils import find_in_data_path
 
 
 class OneBillionWord(TextFile):
@@ -46,18 +46,16 @@ class OneBillionWord(TextFile):
             if not all(partition in range(1, 100)
                        for partition in which_partitions):
                 raise ValueError
-            files = [os.path.join(
-                config.data_path, '1-billion-word',
-                'training-monolingual.tokenized.shuffled',
-                'news.en-{:05d}-of-00100'.format(partition))
+            files = [find_in_data_path(os.path.join(
+                '1-billion-word', 'training-monolingual.tokenized.shuffled',
+                'news.en-{:05d}-of-00100'.format(partition)))
                 for partition in which_partitions]
         else:
             if not all(partition in range(50)
                        for partition in which_partitions):
                 raise ValueError
-            files = [os.path.join(
-                config.data_path, '1-billion-word',
-                'heldout-monolingual.tokenized.shuffled',
-                'news.en.heldout-{:05d}-of-00050'.format(partition))
+            files = [find_in_data_path(os.path.join(
+                '1-billion-word', 'heldout-monolingual.tokenized.shuffled',
+                'news.en.heldout-{:05d}-of-00050'.format(partition)))
                 for partition in which_partitions]
         super(OneBillionWord, self).__init__(files, dictionary, **kwargs)

--- a/fuel/datasets/binarized_mnist.py
+++ b/fuel/datasets/binarized_mnist.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 from fuel.datasets import H5PYDataset
 from fuel.utils import find_in_data_path
 

--- a/fuel/datasets/binarized_mnist.py
+++ b/fuel/datasets/binarized_mnist.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 
-from fuel import config
 from fuel.datasets import H5PYDataset
+from fuel.utils import find_in_data_path
 
 
 class BinarizedMNIST(H5PYDataset):
@@ -44,9 +44,6 @@ class BinarizedMNIST(H5PYDataset):
 
     def __init__(self, which_sets, load_in_memory=True, **kwargs):
         super(BinarizedMNIST, self).__init__(
-            self.data_path, which_sets=which_sets,
+            file_or_path=find_in_data_path(self.filename),
+            which_sets=which_sets,
             load_in_memory=load_in_memory, **kwargs)
-
-    @property
-    def data_path(self):
-        return os.path.join(config.data_path, self.filename)

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -1,8 +1,8 @@
 import os
 
-from fuel import config
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
+from fuel.utils import find_in_data_path
 
 
 class CIFAR10(H5PYDataset):
@@ -36,8 +36,6 @@ class CIFAR10(H5PYDataset):
 
     def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', True)
-        super(CIFAR10, self).__init__(self.data_path, which_sets, **kwargs)
-
-    @property
-    def data_path(self):
-        return os.path.join(config.data_path, self.filename)
+        super(CIFAR10, self).__init__(
+            file_or_path=find_in_data_path(self.filename),
+            which_sets=which_sets, **kwargs)

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -1,5 +1,3 @@
-import os
-
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
 from fuel.utils import find_in_data_path

--- a/fuel/datasets/cifar100.py
+++ b/fuel/datasets/cifar100.py
@@ -1,8 +1,8 @@
 import os
 
-from fuel import config
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
+from fuel.utils import find_in_data_path
 
 
 class CIFAR100(H5PYDataset):
@@ -42,8 +42,6 @@ class CIFAR100(H5PYDataset):
 
     def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', True)
-        super(CIFAR100, self).__init__(self.data_path, which_sets, **kwargs)
-
-    @property
-    def data_path(self):
-        return os.path.join(config.data_path, self.filename)
+        super(CIFAR100, self).__init__(
+            file_or_path=find_in_data_path(self.filename),
+            which_sets=which_sets, **kwargs)

--- a/fuel/datasets/cifar100.py
+++ b/fuel/datasets/cifar100.py
@@ -1,5 +1,3 @@
-import os
-
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
 from fuel.utils import find_in_data_path

--- a/fuel/datasets/mnist.py
+++ b/fuel/datasets/mnist.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
 
-from fuel import config
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
+from fuel.utils import find_in_data_path
 
 
 class MNIST(H5PYDataset):
@@ -34,8 +34,6 @@ class MNIST(H5PYDataset):
 
     def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', True)
-        super(MNIST, self).__init__(self.data_path, which_sets, **kwargs)
-
-    @property
-    def data_path(self):
-        return os.path.join(config.data_path, self.filename)
+        super(MNIST, self).__init__(
+            file_or_path=find_in_data_path(self.filename),
+            which_sets=which_sets, **kwargs)

--- a/fuel/datasets/mnist.py
+++ b/fuel/datasets/mnist.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
 from fuel.utils import find_in_data_path

--- a/fuel/datasets/svhn.py
+++ b/fuel/datasets/svhn.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
 
-from fuel import config
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
+from fuel.utils import find_in_data_path
 
 
 class SVHN(H5PYDataset):
@@ -42,14 +42,15 @@ class SVHN(H5PYDataset):
         argument.
 
     """
-    filename = 'svhn_format_{}.hdf5'
+    _filename = 'svhn_format_{}.hdf5'
     default_transformers = uint8_pixels_to_floatX(('features',))
 
     def __init__(self, which_format, which_sets, **kwargs):
         self.which_format = which_format
-        super(SVHN, self).__init__(self.data_path, which_sets, **kwargs)
+        super(SVHN, self).__init__(
+            file_or_path=find_in_data_path(self.filename),
+            which_sets=which_sets, **kwargs)
 
     @property
-    def data_path(self):
-        return os.path.join(
-            config.data_path, self.filename.format(self.which_format))
+    def filename(self):
+        return self._filename.format(self.which_format)

--- a/fuel/datasets/svhn.py
+++ b/fuel/datasets/svhn.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 from fuel.datasets import H5PYDataset
 from fuel.transformers.defaults import uint8_pixels_to_floatX
 from fuel.utils import find_in_data_path

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -1,6 +1,9 @@
 import collections
+import os
 
 import six
+
+from fuel import config
 
 
 # See http://python3porting.com/differences.html#buffer
@@ -8,6 +11,32 @@ if six.PY3:
     buffer_ = memoryview
 else:
     buffer_ = buffer  # noqa
+
+
+def find_in_data_path(filename):
+    """Searches for a file within Fuel's data path.
+
+    This function loops over all paths defined in Fuel's data path and
+    returns the first path in which the file is found.
+
+    Returns
+    -------
+    file_path : str
+        Path to the first file matching `filename` found in Fuel's
+        data path.
+
+    Raises
+    ------
+    IOError
+        If the file doesn't appear in Fuel's data path.
+
+    """
+    for path in config.data_path.split(os.path.pathsep):
+        path = os.path.expanduser(os.path.expandvars(path))
+        file_path = os.path.join(path, filename)
+        if os.path.isfile(file_path):
+            return file_path
+    raise IOError("{} not found in Fuel's data path".format(filename))
 
 
 def lazy_property_factory(lazy_property):

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -19,6 +19,11 @@ def find_in_data_path(filename):
     This function loops over all paths defined in Fuel's data path and
     returns the first path in which the file is found.
 
+    Parameters
+    ----------
+    filename : str
+        Name of the file to find.
+
     Returns
     -------
     file_path : str

--- a/tests/test_binarized_mnist.py
+++ b/tests/test_binarized_mnist.py
@@ -1,9 +1,7 @@
 import hashlib
-import os
 
 from numpy.testing import assert_raises, assert_equal
 
-from fuel import config
 from fuel.datasets import BinarizedMNIST
 from tests import skip_if_not_available
 

--- a/tests/test_binarized_mnist.py
+++ b/tests/test_binarized_mnist.py
@@ -57,8 +57,3 @@ def test_binarized_mnist_axes():
 
 def test_binarized_mnist_invalid_split():
     assert_raises(ValueError, BinarizedMNIST, ('dummy',))
-
-
-def test_binarized_mnist_data_path():
-    assert BinarizedMNIST(('train',)).data_path == os.path.join(
-        config.data_path, 'binarized_mnist.hdf5')

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy
 
 from numpy.testing import assert_raises, assert_equal, assert_allclose

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -70,10 +70,3 @@ def test_mnist_invalid_split():
     skip_if_not_available(datasets=['mnist.hdf5'])
 
     assert_raises(ValueError, MNIST, ('dummy',))
-
-
-def test_mnist_data_path():
-    skip_if_not_available(datasets=['mnist.hdf5'])
-
-    assert MNIST(('train',)).data_path == os.path.join(config.data_path,
-                                                       'mnist.hdf5')

--- a/tests/test_svhn.py
+++ b/tests/test_svhn.py
@@ -20,8 +20,7 @@ def test_svhn():
         f.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         f.close()
         dataset = SVHN(which_format=2, which_sets=('train',))
-        assert_equal(dataset.data_path,
-                     os.path.join(config.data_path, 'svhn_format_2.hdf5'))
+        assert_equal(dataset.filename, 'svhn_format_2.hdf5')
     finally:
         config.data_path = data_path
         os.remove('svhn_format_2.hdf5')


### PR DESCRIPTION
Fixes #168. Fixes #169.

The data path now supports a sequence of paths separated by an os-specific delimiter (':' for Linux and OSX, ';' for Windows) via `os.path.pathsep`.

It also expands '~' and references to environment variables via `os.path.expanduser` and `os.path.expandvars`.