### PR TITLE
Force sources attrib of FilterSources to be a tuple

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -643,7 +643,7 @@ class FilterSources(Transformer):
                              "data_stream.sources")
 
         # keep order of data_stream.sources
-        self.sources = [s for s in data_stream.sources if s in sources]
+        self.sources = tuple([s for s in data_stream.sources if s in sources])
 
     def get_data(self, request=None):
         if request is not None:

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -643,7 +643,7 @@ class FilterSources(Transformer):
                              "data_stream.sources")
 
         # keep order of data_stream.sources
-        self.sources = tuple([s for s in data_stream.sources if s in sources])
+        self.sources = tuple(s for s in data_stream.sources if s in sources)
 
     def get_data(self, request=None):
         if request is not None:


### PR DESCRIPTION
AbstractDataStream requires that sources be a tuple. When sources are a list one get errors on concatenation with tuples, e.g. when a FilterSources transformer is chained with a Mapping one (there is then a list to tuple concatenation at https://github.com/mila-udem/fuel/blob/master/fuel/transformers/__init__.py#L107-L108 )