### PR TITLE
Turn chain into a list to avoid indices depletion #191

### DIFF
--- a/fuel/schemes.py
+++ b/fuel/schemes.py
@@ -271,8 +271,8 @@ def cross_validation(scheme_class, num_examples, num_folds, strict=True,
     for i in xrange(num_folds):
         begin = num_examples * i // num_folds
         end = num_examples * (i+1) // num_folds
-        train = scheme_class(chain(xrange(0, begin),
-                                   xrange(end, num_examples)),
+        train = scheme_class(list(chain(xrange(0, begin),
+                                        xrange(end, num_examples))),
                              **kwargs)
         valid = scheme_class(xrange(begin, end), **kwargs)
 

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -117,15 +117,28 @@ def test_cross_validation():
     (train, valid, valid_size) = next(cross)
     assert list(train.get_request_iterator()) == list(range(3, 10))
     assert list(valid.get_request_iterator()) == list(range(0, 3))
+
+    # test that indices are not depleted
+    assert list(train.get_request_iterator()) == list(range(3, 10))
+    assert list(valid.get_request_iterator()) == list(range(0, 3))
     assert valid_size == 3
 
     (train, valid, valid_size) = next(cross)
     assert (list(train.get_request_iterator()) ==
             list(range(0, 3)) + list(range(6, 10)))
     assert list(valid.get_request_iterator()) == list(range(3, 6))
+
+    # test that indices are not depleted
+    assert (list(train.get_request_iterator()) ==
+            list(range(0, 3)) + list(range(6, 10)))
+    assert list(valid.get_request_iterator()) == list(range(3, 6))
     assert valid_size == 3
 
     (train, valid, valid_size) = next(cross)
+    assert list(train.get_request_iterator()) == list(range(0, 6))
+    assert list(valid.get_request_iterator()) == list(range(6, 10))
+
+    # test that indices are not depleted
     assert list(train.get_request_iterator()) == list(range(0, 6))
     assert list(valid.get_request_iterator()) == list(range(6, 10))
     assert valid_size == 4
@@ -139,7 +152,15 @@ def test_cross_validation():
     assert list(train.get_request_iterator()) == [[4, 5], [6, 7]]
     assert list(valid.get_request_iterator()) == [[0, 1], [2, 3]]
 
+    # test that indices are not depleted
+    assert list(train.get_request_iterator()) == [[4, 5], [6, 7]]
+    assert list(valid.get_request_iterator()) == [[0, 1], [2, 3]]
+
     (train, valid) = next(cross)
+    assert list(train.get_request_iterator()) == [[0, 1], [2, 3]]
+    assert list(valid.get_request_iterator()) == [[4, 5], [6, 7]]
+
+    # test that indices are not depleted
     assert list(train.get_request_iterator()) == [[0, 1], [2, 3]]
     assert list(valid.get_request_iterator()) == [[4, 5], [6, 7]]
 


### PR DESCRIPTION
SequentialScheme gets depleted after one epoch as the chain iterator
gets empty.

Fix #191 