### PR TITLE
Add installation doc

### DIFF
--- a/docs/built_in_datasets.rst
+++ b/docs/built_in_datasets.rst
@@ -111,7 +111,7 @@ argument:
 
     $ fuel-info mnist.hdf5
 
-.. code-block:: plain
+.. code-block:: text
 
     Metadata for mnist.hdf5
     =======================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@ Welcome to Fuel's documentation!
 .. toctree::
    :hidden:
 
+   setup
    overview
    built_in_datasets
    h5py_dataset
@@ -43,7 +44,7 @@ Pylearn2_ neural network libraries.
 .. _mailing list: https://groups.google.com/d/forum/fuel-users
 .. _making a GitHub issue: https://github.com/mila-udem/fuel/issues/new
 .. _Blocks: https://github.com/mila-udem/blocks
-.. _Pylearn2: https://github.com/lisa-lab/pylearb2
+.. _Pylearn2: https://github.com/lisa-lab/pylearn2
 
 Motivation
 ----------
@@ -58,7 +59,8 @@ processing.
 Quickstart
 ----------
 
-Begin by telling Fuel where to find the data it needs. You can do this by
+Once you have :doc:`installed <setup>` Fuel, you can
+begin by telling Fuel where to find the data it needs. You can do this by
 creating a ``.fuelrc`` file:
 
 .. code-block:: bash

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -16,7 +16,7 @@ sight, but can be very powerful.
    RequestIterator -> DataIterator [style=dashed, label=" Argument to"];
    DataIterator -> DataStream [label=" Gets data from"];
    DataStream -> DataStream [style=dashed, label=" Gets data from (wrapper)"];
-   { rank=same; RequestIterator, DataIterator }
+   { rank=same; RequestIterator DataIterator }
 
 Datasets
   Datasets provide an interface to the data we are trying to access. This data

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,9 +1,9 @@
 Installation
 ============
 
-The easiest way to install Fuel is using the Python package manager pip. Fuel
-isn't listed yet on the Python Package Index (PyPI), so you will have to grab it
-directly from GitHub.
+The easiest way to install Fuel is using the Python package manager ``pip``.
+Fuel isn't listed yet on the Python Package Index (PyPI), so you will
+have to grab it directly from GitHub.
 
 .. code-block:: bash
 
@@ -44,10 +44,12 @@ Fuel's requirements are
 * h5py_ and PyTables_ for the HDF5 storage back-end
 * pillow_, providing PIL for image preprocessing
 * Cython_, for fast extensions
-* pyzmq_, to send data across processes
-* picklable_itertools_, for picklable iterators
-* SciPy_, to read from MatLab's .mat format
+* pyzmq_, to efficiently send data across processes
+* picklable_itertools_, for supporting iterator serialization
+* SciPy_, to read from MATLAB's .mat format
 * requests_, to download canonical datasets
+
+nose2_ is an optional requirement, used to run the tests.
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
 .. _nose2: https://nose2.readthedocs.org/
@@ -99,8 +101,7 @@ Documentation
 ~~~~~~~~~~~~~
 
 If you want to build a local copy of the documentation, you can follow
-the instructions at `Blocks' documentation development guidelines`_,
-replacing "Blocks" by "Fuel".
+the instructions in the `documentation development guidelines`_.
 
-.. _Blocks' documentation development guidelines:
+.. _documentation development guidelines:
    http://blocks.readthedocs.org/en/latest/development/docs.html

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,0 +1,106 @@
+Installation
+============
+
+The easiest way to install Fuel is using the Python package manager pip. Fuel
+isn't listed yet on the Python Package Index (PyPI), so you will have to grab it
+directly from GitHub.
+
+.. code-block:: bash
+
+   $ pip install git+git://github.com/mila-udem/fuel.git
+
+This will give you the cutting-edge development version. The latest stable
+release is in the ``stable`` branch and can be installed as follows.
+
+.. code-block:: bash
+
+   $ pip install git+git://github.com/mila-udem/fuel.git@stable
+
+If you don't have administrative rights, add the ``--user`` switch to the
+install commands to install the packages in your home folder. If you want to
+update Fuel, simply repeat the first command with the ``--upgrade`` switch
+added to pull the latest version from GitHub.
+
+.. warning::
+
+   Pip may try to install or update NumPy and SciPy if they are not present or
+   outdated. However, pip's versions might not be linked to an optimized BLAS
+   implementation. To prevent this from happening make sure you update NumPy
+   and SciPy using your system's package manager (e.g.  ``apt-get`` or
+   ``yum``), or use a Python distribution like Anaconda_, before installing
+   Fuel. You can also pass the ``--no-deps`` switch and install all the
+   requirements manually.
+
+   If the installation crashes with ``ImportError: No module named
+   numpy.distutils.core``, install NumPy and try again again.
+
+
+Requirements
+------------
+Fuel's requirements are
+
+* PyYAML_, to parse the configuration file
+* six_, to support both Python 2 and 3 with a single codebase
+* h5py_ and PyTables_ for the HDF5 storage back-end
+* pillow_, providing PIL for image preprocessing
+* Cython_, for fast extensions
+* pyzmq_, to send data across processes
+* picklable_itertools_, for picklable iterators
+* SciPy_, to read from MatLab's .mat format
+* requests_, to download canonical datasets
+
+.. _Anaconda: https://store.continuum.io/cshop/anaconda/
+.. _nose2: https://nose2.readthedocs.org/
+.. _PyYAML: http://pyyaml.org/wiki/PyYAML
+.. _six: http://pythonhosted.org/six/
+.. _h5py: http://www.h5py.org/
+.. _PyTables: http://www.pytables.org/
+.. _SciPy: http://www.scipy.org/
+.. _pillow: https://python-pillow.github.io/
+.. _Cython: http://cython.org/
+.. _pyzmq: https://zeromq.github.io/pyzmq/
+.. _picklable_itertools: https://github.com/dwf/picklable_itertools
+.. _requests: http://docs.python-requests.org/en/latest/
+
+Development
+-----------
+
+If you want to work on Fuel's development, your first step is to `fork Fuel
+on GitHub`_. You will now want to install your fork of Fuel in editable mode.
+To install in your home directory, use the following command, replacing ``USER``
+with your own GitHub user name:
+
+.. code-block:: bash
+
+   $ pip install -e git+git@github.com:USER/fuel.git#egg=fuel[test,docs] --src=$HOME
+
+As with the usual installation, you can use ``--user`` or ``--no-deps`` if you
+need to. You can now make changes in the ``fuel`` directory created by pip,
+push to your repository and make a pull request.
+
+If you had already cloned the GitHub repository, you can use the following
+command from the folder you cloned Fuel to:
+
+.. code-block:: bash
+
+   $ pip install -e file:.#egg=fuel[test,docs]
+
+Fuel contains Cython extensions, which need to be recompiled if you
+update the Cython `.pyx` files. Each time these files are modified, you
+should run:
+
+.. code-block:: bash
+
+   $ python setup.py build_ext --inplace
+
+.. _fork Fuel on GitHub: https://github.com/mila-udem/fuel/fork
+
+Documentation
+~~~~~~~~~~~~~
+
+If you want to build a local copy of the documentation, you can follow
+the instructions at `Blocks' documentation development guidelines`_,
+replacing "Blocks" by "Fuel".
+
+.. _Blocks' documentation development guidelines:
+   http://blocks.readthedocs.org/en/latest/development/docs.html


### PR DESCRIPTION
Should fix #104, at least in part.

These instructions will use the latest version of picklable-itertools on PyPI, rather than the latest GitHub one. This seems to work fine at the moment, but I can change that if needed.