### PR TITLE
Make fuel-* scripts work on Windows

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit =
+    fuel/bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Cython extensions
+fuel/transformers/_image.c
+
 # Distribution / packaging
 .Python
 env/
@@ -52,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Editors
+*~
+*.sw[op]

--- a/fuel/bin/fuel_convert.py
+++ b/fuel/bin/fuel_convert.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-"""Fuel dataset conversion utility.
-
-"""
+"""Fuel dataset conversion utility."""
 import argparse
 import os
 import sys
@@ -75,7 +73,8 @@ def main(args=None):
         fuel_convert_version = converters.__version__.encode('utf-8')
         h5file.attrs['fuel_convert_version'] = fuel_convert_version
         command = [os.path.basename(sys.argv[0])] + sys.argv[1:]
-        h5file.attrs['fuel_convert_command'] = ' '.join(command).encode('utf-8')
+        h5file.attrs['fuel_convert_command'] = (
+            ' '.join(command).encode('utf-8'))
         h5file.flush()
         h5file.close()
 

--- a/fuel/bin/fuel_convert.py
+++ b/fuel/bin/fuel_convert.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""Fuel dataset conversion utility.
+
+"""
 import argparse
 import os
 import sys
@@ -18,7 +21,19 @@ class CheckDirectoryAction(argparse.Action):
             raise ValueError('{} is not a existing directory'.format(values))
 
 
-if __name__ == "__main__":
+def main(args=None):
+    """Entry point for `fuel-convert` script.
+
+    This function can also be imported and used from Python.
+
+    Parameters
+    ----------
+    args : iterable, optional (default: None)
+        A list of arguments that will be passed to Fuel's conversion
+        utility. If this argument is not specified, `sys.argv[1:]` will
+        be used.
+
+    """
     built_in_datasets = dict(converters.all_converters)
     parser = argparse.ArgumentParser(
         description='Conversion script for built-in datasets.')
@@ -36,7 +51,7 @@ if __name__ == "__main__":
             type=str, default=os.getcwd(), action=CheckDirectoryAction)
         subparser_fn(subparser)
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     args_dict = vars(args)
     try:
         func = args_dict.pop('func')
@@ -63,3 +78,7 @@ if __name__ == "__main__":
         h5file.attrs['fuel_convert_command'] = ' '.join(command).encode('utf-8')
         h5file.flush()
         h5file.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuel/bin/fuel_download.py
+++ b/fuel/bin/fuel_download.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-"""Fuel dataset downloading utility.
-
-"""
+"""Fuel dataset downloading utility."""
 import argparse
 import os
 
@@ -14,6 +12,7 @@ Some files for this dataset do not have a download URL.
 Provide a URL prefix with --url-prefix to prepend to the filenames,
 e.g. http://path.to/files/
 """.strip()
+
 
 def main(args=None):
     """Entry point for `fuel-download` script.

--- a/fuel/bin/fuel_download.py
+++ b/fuel/bin/fuel_download.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""Fuel dataset downloading utility.
+
+"""
 import argparse
 import os
 
@@ -12,7 +15,19 @@ Provide a URL prefix with --url-prefix to prepend to the filenames,
 e.g. http://path.to/files/
 """.strip()
 
-if __name__ == "__main__":
+def main(args=None):
+    """Entry point for `fuel-download` script.
+
+    This function can also be imported and used from Python.
+
+    Parameters
+    ----------
+    args : iterable, optional (default: None)
+        A list of arguments that will be passed to Fuel's downloading
+        utility. If this argument is not specified, `sys.argv[1:]` will
+        be used.
+
+    """
     built_in_datasets = dict(downloaders.all_downloaders)
     parser = argparse.ArgumentParser(
         description='Download script for built-in datasets.')
@@ -38,3 +53,7 @@ if __name__ == "__main__":
         func(**args_dict)
     except NeedURLPrefix:
         parser.error(url_prefix_message)
+
+
+if __name__ == "__main__":
+    main()

--- a/fuel/bin/fuel_info.py
+++ b/fuel/bin/fuel_info.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-"""Fuel utility for extracting metadata
-
-"""
+"""Fuel utility for extracting metadata."""
 import argparse
 import os
 
@@ -19,6 +17,7 @@ message_body_template = """
         H5PYDataset     {}
         fuel.converters {}
 """
+
 
 def main(args=None):
     """Entry point for `fuel-info` script.

--- a/fuel/bin/fuel_info.py
+++ b/fuel/bin/fuel_info.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
+"""Fuel utility for extracting metadata
+
+"""
 import argparse
 import os
 
 import h5py
 
-message_prefix = 'Metadata for {}'
-message_body = """
+message_prefix_template = 'Metadata for {}'
+message_body_template = """
 
     The command used to generate this file is
 
@@ -17,8 +20,19 @@ message_body = """
         fuel.converters {}
 """
 
+def main(args=None):
+    """Entry point for `fuel-info` script.
 
-if __name__ == "__main__":
+    This function can also be imported and used from Python.
+
+    Parameters
+    ----------
+    args : iterable, optional (default: None)
+        A list of arguments that will be passed to Fuel's information
+        utility. If this argument is not specified, `sys.argv[1:]` will
+        be used.
+
+    """
     parser = argparse.ArgumentParser(
         description='Extracts metadata from a Fuel-converted HDF5 file.')
     parser.add_argument("filename", help="HDF5 file to analyze")
@@ -29,9 +43,14 @@ if __name__ == "__main__":
         fuel_convert_version = h5file.attrs.get('fuel_convert_version', 'N/A')
         fuel_convert_command = h5file.attrs.get('fuel_convert_command', 'N/A')
 
-    message_prefix = message_prefix.format(os.path.basename(args.filename))
-    message_body = message_body.format(
+    message_prefix = message_prefix_template.format(
+        os.path.basename(args.filename))
+    message_body = message_body_template.format(
         fuel_convert_command, interface_version, fuel_convert_version)
     message = ''.join(['\n', message_prefix, '\n', '=' * len(message_prefix),
                        message_body])
     print(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,11 @@ setup(
     extras_require={
         'test': ['nose', 'nose2', 'mock']
     },
-    scripts=['bin/fuel-convert', 'bin/fuel-download', 'bin/fuel-info'],
+    entry_points={
+        'console_scripts': ['fuel-convert = fuel.bin.fuel_convert:main',
+                            'fuel-download = fuel.bin.fuel_download:main',
+                            'fuel-info = fuel.bin.fuel_info:main']
+    },
     ext_modules=cythonize(Extension("fuel.transformers._image",
                                     ["fuel/transformers/_image.pyx"],
                                     extra_compile_args=extra_compile_args))


### PR DESCRIPTION
This uses the entry_points/console_scripts feature of setup.py,
so the executables will be created when running pip install,
for instance.