### PR TITLE
Fix deserialization issues in H5PYDataset

### DIFF
--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -581,7 +581,7 @@ class H5PYDataset(Dataset):
         return None if self.load_in_memory else self._out_of_memory_open()
 
     def _out_of_memory_open(self):
-        if not self._external_file_handle:
+        if not self.external_file_handle:
             if self.path not in self._file_handles:
                 handle = h5py.File(
                     name=self.path, mode="r", driver=self.driver)
@@ -593,7 +593,7 @@ class H5PYDataset(Dataset):
             self._out_of_memory_close()
 
     def _out_of_memory_close(self):
-        if not self._external_file_handle:
+        if not self.external_file_handle:
             self._ref_counts[self.path] -= 1
             if not self._ref_counts[self.path]:
                 del self._ref_counts[self.path]
@@ -602,8 +602,8 @@ class H5PYDataset(Dataset):
 
     @property
     def _file_handle(self):
-        if self._external_file_handle:
-            return self._external_file_handle
+        if self.external_file_handle:
+            return self.external_file_handle
         elif self.path in self._file_handles:
             return self._file_handles[self.path]
         else:

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -154,6 +154,10 @@ class TestH5PYDataset(object):
             h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
             dataset = cPickle.loads(
                 cPickle.dumps(H5PYDataset(h5file, which_sets=('train',))))
+            # Make sure _out_of_memory_{open,close} accesses
+            # external_file_handle rather than _external_file_handle
+            dataset._out_of_memory_open()
+            dataset._out_of_memory_close()
             assert dataset.data_sources is None
         finally:
             os.remove('file.hdf5')


### PR DESCRIPTION
Fixes #215.

@rizar correctly identified that this was caused by `H5PYDataset` accessing `self._external_file_handle` rather than `self.external_file_handle` outside `H5PYDataset.load`.

Git blame points out this is my mistake, sorry about that!

I added this case to the serialization unit test so it's catched the next time.