### PR TITLE
Subset refactor

### DIFF
--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -7,7 +7,7 @@ from picklable_itertools import iter_, izip
 
 from fuel.schemes import SequentialExampleScheme
 from fuel.streams import DataStream
-from fuel.utils import iterable_fancy_indexing, Subset
+from fuel.utils import Subset
 
 
 @add_metaclass(ABCMeta)

--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -7,7 +7,7 @@ from picklable_itertools import iter_, izip
 
 from fuel.schemes import SequentialExampleScheme
 from fuel.streams import DataStream
-from fuel.utils import iterable_fancy_indexing
+from fuel.utils import iterable_fancy_indexing, Subset
 
 
 @add_metaclass(ABCMeta)
@@ -354,6 +354,7 @@ class IndexableDataset(Dataset):
 
         self.start = start
         self.stop = stop
+        self.subset = Subset(slice(start, stop), self.num_examples)
 
     def __getattr__(self, attr):
         if (attr not in ['sources', 'indexables', '_sources'] and
@@ -375,8 +376,5 @@ class IndexableDataset(Dataset):
     def get_data(self, state=None, request=None):
         if state is not None or request is None:
             raise ValueError
-        if isinstance(request, collections.Iterable):
-            return tuple(iterable_fancy_indexing(indexable, request)
-                         for indexable in self.indexables)
-        else:
-            return tuple(indexable[request] for indexable in self.indexables)
+        return tuple(self.subset.index_within_subset(indexable, request)
+                     for indexable in self.indexables)

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -571,13 +571,13 @@ class H5PYDataset(Dataset):
             data.append(
                 subset.index_within_subset(
                     handle[source_name], request,
-                    safe_hdf5_indexing=self.sort_indices))
+                    sort_indices=self.sort_indices))
             # If this source has variable length, get the shapes as well
             if source_name in self.vlen_sources:
                 shapes.append(
                     subset.index_within_subset(
                         handle[source_name].dims[0]['shapes'], request,
-                        safe_hdf5_indexing=self.sort_indices))
+                        sort_indices=self.sort_indices))
             else:
                 shapes.append(None)
         return data, shapes

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -8,8 +8,7 @@ import tables
 from six.moves import zip, range
 
 from fuel.datasets import Dataset
-from fuel.utils import (do_not_pickle_attributes, iterable_fancy_indexing,
-                        Subset)
+from fuel.utils import do_not_pickle_attributes, Subset
 
 
 @do_not_pickle_attributes('nodes', 'h5file')
@@ -499,7 +498,6 @@ class H5PYDataset(Dataset):
             data_sources = []
             source_shapes = []
             for source_name, subset in zip(self.sources, self.subsets):
-                list_or_slice = subset.list_or_slice
                 data_sources.append(
                     subset.index_within_subset(
                         handle[source_name], slice(None)))

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -585,13 +585,13 @@ class H5PYDataset(Dataset):
             data.append(
                 subset.index_within_subset(
                     handle[source_name], request,
-                    sort_indices=self.sort_indices))
+                    safe_hdf5_indexing=self.sort_indices))
             # If this source has variable length, get the shapes as well
             if source_name in self.vlen_sources:
                 shapes.append(
                     subset.index_within_subset(
                         handle[source_name].dims[0]['shapes'], request,
-                        sort_indices=self.sort_indices))
+                        safe_hdf5_indexing=self.sort_indices))
             else:
                 shapes.append(None)
         return data, shapes

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -468,7 +468,8 @@ class H5PYDataset(Dataset):
         handle = self._file_handle
 
         # Infer subsets based on `which_sets`
-        subsets = [None for source_name in self.sources]
+        subsets = [Subset.empty_subset(len(handle[source_name]))
+                   for source_name in self.sources]
         for split in self.which_sets:
             start_stop = self.get_start_stop(handle, split)
             indices = self.get_indices(handle, split)
@@ -480,10 +481,7 @@ class H5PYDataset(Dataset):
                     source_split_subset = Subset(
                         slice(*start_stop[source_name]),
                         len(handle[source_name]))
-                if subsets[i] is None:
-                    subsets[i] = source_split_subset
-                else:
-                    subsets[i] += source_split_subset
+                subsets[i] += source_split_subset
         # Sanity check to make sure that all sources have equal length
         if any(subset.num_examples != subsets[0].num_examples for subset in
                 subsets):

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -178,7 +178,7 @@ class H5PYDataset(Dataset):
         if which_sets_invalid_value:
             raise ValueError('`which_sets` should be an iterable of strings')
         self.which_sets = which_sets
-        self._subset_within_sets = subset if subset else slice(None)
+        self.user_given_subset = subset if subset else slice(None)
         self.load_in_memory = load_in_memory
         self.driver = driver
         self.sort_indices = sort_indices
@@ -472,7 +472,7 @@ class H5PYDataset(Dataset):
             raise ValueError("sources have different lengths")
         # Produce the final subsets by taking the `subset` constructor argument
         # into account.
-        self.subsets = [Subset.subset_of(subset, self._subset_within_sets)
+        self.subsets = [Subset.subset_of(subset, self.user_given_subset)
                         for subset in subsets]
 
         # Load data sources and source shapes (if requested)

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -77,26 +77,23 @@ class Subset(object):
                                   self.original_num_examples)
         # Slice-based subsets are merged into a slice-based subset if they
         # overlap, otherwise they're converted to a list-based subset.
-        else:
-            self_sss = self.slice_to_numerical_args(
-                self.list_or_slice, self.original_num_examples)
-            self_start, self_stop, self_step = self_sss
-            other_sss = self.slice_to_numerical_args(
-                other.list_or_slice, other.original_num_examples)
-            other_start, other_stop, other_step = other_sss
-            # In case of overlap, the solution is to choose the smallest start
-            # value and largest stop value.
-            if not (self_stop < other_start or self_start > other_stop):
-                return self.__class__(slice(min(self_start, other_start),
-                                            max(self_stop, other_stop),
-                                            self_step),
-                                      self.original_num_examples)
-            # Everything else is transformed into lists before merging.
-            else:
-                return self.__class__(
-                    self.get_list_representation() +
-                    other.get_list_representation(),
-                    self.original_num_examples)
+        self_sss = self.slice_to_numerical_args(
+            self.list_or_slice, self.original_num_examples)
+        self_start, self_stop, self_step = self_sss
+        other_sss = self.slice_to_numerical_args(
+            other.list_or_slice, other.original_num_examples)
+        other_start, other_stop, other_step = other_sss
+        # In case of overlap, the solution is to choose the smallest start
+        # value and largest stop value.
+        if not (self_stop < other_start or self_start > other_stop):
+            return self.__class__(slice(min(self_start, other_start),
+                                        max(self_stop, other_stop),
+                                        self_step),
+                                  self.original_num_examples)
+        # Everything else is transformed into lists before merging.
+        return self.__class__(
+            self.get_list_representation() + other.get_list_representation(),
+            self.original_num_examples)
 
     def __getitem__(self, key):
         """Translates a request from this subset to the dataset.

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -117,24 +117,21 @@ class Subset(object):
         # anything
         if key == slice(None, None, None):
             return self.list_or_slice
-        elif self._is_list(key):
+        if self._is_list(key):
             if self.is_list:
                 return [self.list_or_slice[index] for index in key]
-            else:
-                start, stop, step = self.slice_to_numerical_args(
-                    self.list_or_slice, self.original_num_examples)
-                return [start + (index * step) for index in key]
-        else:
-            if self.is_list:
-                return self.list_or_slice[key]
-            else:
-                start, stop, step = self.slice_to_numerical_args(
-                    self.list_or_slice, self.original_num_examples)
-                key_start, key_stop, key_step = self.slice_to_numerical_args(
-                    key, self.num_examples)
-                return slice(start + step * key_start,
-                             start + step * key_stop,
-                             step * key_step)
+            start, stop, step = self.slice_to_numerical_args(
+                self.list_or_slice, self.original_num_examples)
+            return [start + (index * step) for index in key]
+        if self.is_list:
+            return self.list_or_slice[key]
+        start, stop, step = self.slice_to_numerical_args(
+            self.list_or_slice, self.original_num_examples)
+        key_start, key_stop, key_step = self.slice_to_numerical_args(
+            key, self.num_examples)
+        return slice(start + step * key_start,
+                     start + step * key_stop,
+                     step * key_step)
 
     @classmethod
     def subset_of(cls, subset, list_or_slice):

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -193,7 +193,7 @@ class Subset(object):
             of indices, work around the fancy indexing limitation that
             requires lists of indices to be sorted by indexing in sorted
             order and reshuffling the result in the original order.
-            Default to `True`.
+            Defaults to `True`.
 
         """
         # Translate the request within the context of this subset to a

--- a/tests/test_cifar10.py
+++ b/tests/test_cifar10.py
@@ -32,3 +32,8 @@ def test_cifar10():
     assert data.dtype == config.floatX
 
     assert_raises(ValueError, CIFAR10, ('valid',))
+
+    dummy = CIFAR10(('train',), subset=slice(50000, 60000))
+    handle = dummy.open()
+    assert_raises(ValueError, dummy.get_data, handle, slice(0, 10000))
+    dummy.close(handle)

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -131,15 +131,6 @@ class TestH5PYDataset(object):
         assert (all(source in all_sources for source in sources) and
                 all(source in sources for source in all_sources))
 
-    def test_unsorted_fancy_index_1(self):
-        indexable = numpy.arange(10)
-        assert_equal(H5PYDataset.unsorted_fancy_index([0], indexable), [0])
-
-    def test_unsorted_fancy_index_gt_1(self):
-        indexable = numpy.arange(10)
-        assert_equal(H5PYDataset.unsorted_fancy_index([0, 5, 2], indexable),
-                     [0, 5, 2])
-
     def test_axis_labels(self):
         dataset = H5PYDataset(self.h5file, which_sets=('train',))
         assert dataset.axis_labels == {'features': ('batch', 'feature'),

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -232,15 +232,6 @@ class TestH5PYDataset(object):
         assert_raises(TypeError, dataset.get_data, handle, [7, 4, 6, 2, 5])
         dataset.close(handle)
 
-    def test_subset_step_gt_1(self):
-        dataset = H5PYDataset(
-            self.h5file, which_sets=('train',), subset=slice(0, 10, 2))
-        handle = dataset.open()
-        assert_equal(dataset.get_data(handle, [0, 1, 2, 3, 4]),
-                     (self.features[slice(0, 10, 2)],
-                      self.targets[slice(0, 10, 2)]))
-        dataset.close(handle)
-
     def test_value_error_on_unequal_sources(self):
         def get_subsets():
             return H5PYDataset(self.h5file, which_sets=('train',)).subsets

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -322,12 +322,13 @@ class TestH5PYDataset(object):
         dataset.close(handle)
 
     def test_index_subset_unsorted(self):
+        # A subset should have the same ordering no matter how you specify it.
         dataset = H5PYDataset(
             self.h5file, which_sets=('train',), subset=[0, 4, 2])
         handle = dataset.open()
         request = slice(0, 3)
         assert_equal(dataset.get_data(handle, request),
-                     (self.features[[0, 4, 2]], self.targets[[0, 4, 2]]))
+                     (self.features[[0, 2, 4]], self.targets[[0, 2, 4]]))
         dataset.close(handle)
 
     def test_vlen_axis_labels(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,10 +51,6 @@ class TestSubset(object):
         assert_equal(Subset(slice(2, 37, 7), 50).num_examples, 5)
         assert_equal(Subset(slice(2, 37, 8), 50).num_examples, 5)
 
-    def test_is_slice_property(self):
-        assert Subset(slice(None, None, None), 2).is_slice
-        assert not Subset([0, 1, 3], 4).is_slice
-
     def test_is_list_property(self):
         assert not Subset(slice(None, None, None), 2).is_list
         assert Subset([0, 1, 3], 4).is_list

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 
+import numpy
 from numpy.testing import assert_raises, assert_equal
 from six.moves import range, cPickle
 
@@ -65,6 +66,10 @@ class TestSubset(object):
     def test_contiguous_lists_are_transformed_into_slices(self):
         assert_equal(Subset([1, 2, 3], 10).list_or_slice, slice(1, 4, None))
 
+    def test_none_slice_request(self):
+        assert_equal(Subset([1, 3, 5, 7], 8)[slice(None)], [1, 3, 5, 7])
+        assert_equal(Subset(slice(0, 8, 2), 8)[slice(None)], slice(0, 8, 2))
+
     def test_list_subset_list_request(self):
         assert_equal(Subset([0, 2, 5, 7, 10, 15], 16)[[3, 2, 4]], [7, 5, 10])
 
@@ -121,6 +126,15 @@ class TestSubset(object):
         assert_equal((Subset(slice(0, 8, 3), 20) +
                       Subset(slice(12, 19, 2), 20)).list_or_slice,
                       [0, 3, 6, 12, 14, 16, 18])
+
+    def test_unsorted_fancy_index_1(self):
+        indexable = numpy.arange(10)
+        assert_equal(Subset.unsorted_fancy_index([0], indexable), [0])
+
+    def test_unsorted_fancy_index_gt_1(self):
+        indexable = numpy.arange(10)
+        assert_equal(Subset.unsorted_fancy_index([0, 5, 2], indexable),
+                     [0, 5, 2])
 
 
 @do_not_pickle_attributes("non_picklable", "bulky_attr")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,13 +127,13 @@ class TestSubset(object):
                       Subset(slice(12, 19, 2), 20)).list_or_slice,
                       [0, 3, 6, 12, 14, 16, 18])
 
-    def test_unsorted_fancy_index_1(self):
+    def test_safe_unsorted_fancy_index_1(self):
         indexable = numpy.arange(10)
-        assert_equal(Subset.unsorted_fancy_index([0], indexable), [0])
+        assert_equal(Subset.safe_unsorted_fancy_index(indexable, [0]), [0])
 
-    def test_unsorted_fancy_index_gt_1(self):
+    def test_safe_unsorted_fancy_index_gt_1(self):
         indexable = numpy.arange(10)
-        assert_equal(Subset.unsorted_fancy_index([0, 5, 2], indexable),
+        assert_equal(Subset.safe_unsorted_fancy_index(indexable, [0, 5, 2]),
                      [0, 5, 2])
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,8 @@ class TestSubset(object):
     def test_raises_value_error_on_empty_slice(self):
         # Subset should not support slices that lead to an empty subset
         assert_raises(ValueError, Subset, slice(11, 10, None), 15)
+        assert_raises(ValueError, Subset, slice(13, 18, None), 10)
+        assert_raises(ValueError, Subset, slice(10, 10, None), 10)
 
     def test_list_num_examples(self):
         assert_equal(Subset([0, 3, 8, 13], 15).num_examples, 4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import operator
 import os
 import shutil
 import tempfile
@@ -7,7 +8,117 @@ from six.moves import range, cPickle
 
 from fuel import config
 from fuel.iterator import DataIterator
-from fuel.utils import do_not_pickle_attributes, find_in_data_path
+from fuel.utils import do_not_pickle_attributes, find_in_data_path, Subset
+
+
+class TestSubset(object):
+    def test_raises_value_error_on_negative_indices(self):
+        # Subset should not support lists with negative elements.
+        assert_raises(ValueError, Subset, [0, -1], 2)
+
+    def test_raises_value_error_on_too_large_indices(self):
+        # Subset should not support lists with indices greater or equal to
+        # the original number of examples.
+        assert_raises(ValueError, Subset, [0, 10], 2)
+
+    def test_raises_value_error_on_empty_list(self):
+        # Subset should not support empty lists
+        assert_raises(ValueError, Subset, [], 15)
+
+    def test_raises_value_error_on_negative_slices(self):
+        # Subset should not support slices with negative start, stop or step.
+        assert_raises(ValueError, Subset, slice(-1, None, None), 2)
+        assert_raises(ValueError, Subset, slice(None, -1, None), 2)
+        assert_raises(ValueError, Subset, slice(None, None, -1), 2)
+
+    def test_raises_value_error_on_slice_out_of_bound(self):
+        # Subset should not support slices that go out of bound with respect to
+        # the original number of examples.
+        assert_raises(ValueError, Subset, slice(None, 10, None), 2)
+
+    def test_raises_value_error_on_empty_slice(self):
+        # Subset should not support slices that lead to an empty subset
+        assert_raises(ValueError, Subset, slice(11, 10, None), 15)
+
+    def test_list_num_examples(self):
+        assert_equal(Subset([0, 3, 8, 13], 15).num_examples, 4)
+
+    def test_slice_num_examples(self):
+        assert_equal(Subset(slice(3, 18, 1), 50).num_examples, 15)
+        assert_equal(Subset(slice(2, 37, 7), 50).num_examples, 5)
+        assert_equal(Subset(slice(2, 37, 8), 50).num_examples, 5)
+
+    def test_is_slice_property(self):
+        assert Subset(slice(None, None, None), 2).is_slice
+        assert not Subset([0, 1, 3], 4).is_slice
+
+    def test_is_list_property(self):
+        assert not Subset(slice(None, None, None), 2).is_list
+        assert Subset([0, 1, 3], 4).is_list
+
+    def test_lists_are_unique_and_sorted(self):
+        assert_equal(Subset([0, 3, 3, 5], 10).list_or_slice, [0, 3, 5])
+        assert_equal(Subset([0, 3, 1, 5], 10).list_or_slice, [0, 1, 3, 5])
+
+    def test_contiguous_lists_are_transformed_into_slices(self):
+        assert_equal(Subset([1, 2, 3], 10).list_or_slice, slice(1, 4, None))
+
+    def test_list_subset_list_request(self):
+        assert_equal(Subset([0, 2, 5, 7, 10, 15], 16)[[3, 2, 4]], [7, 5, 10])
+
+    def test_list_subset_slice_request(self):
+        assert_equal(Subset([0, 2, 5, 7, 10, 15], 16)[slice(1, 4, 2)], [2, 7])
+
+    def test_slice_subset_list_request(self):
+        assert_equal(Subset(slice(1, 14, 3), 16)[[3, 2, 4]], [10, 7, 13])
+
+    def test_slice_subset_slice_request(self):
+        assert_equal(Subset(slice(1, 14, 3), 16)[slice(1, 4, 2)],
+                     slice(4, 13, 6))
+
+    def test_add_raises_value_error_when_incompatible(self):
+        # Adding two Subset instances should only work when they have the same
+        # number of original examples.
+        assert_raises(
+            ValueError, operator.add, Subset([1, 3], 10), Subset([2, 4], 11))
+
+    def test_add_list_list(self):
+        assert_equal((Subset([0, 3, 2, 8], 10) +
+                      Subset([0, 4, 5], 10)).list_or_slice,
+                     [0, 2, 3, 4, 5, 8])
+
+    def test_add_list_slice(self):
+        assert_equal((Subset([0, 3, 2, 8], 10) +
+                      Subset(slice(1, 9, 3), 10)).list_or_slice,
+                      [0, 1, 2, 3, 4, 7, 8])
+
+    def test_add_slice_list(self):
+        assert_equal((Subset(slice(1, 9, 3), 10) +
+                      Subset([0, 3, 2, 8], 10)).list_or_slice,
+                      [0, 1, 2, 3, 4, 7, 8])
+
+    def test_add_contiguous_single_step_slice_slice(self):
+        assert_equal((Subset(slice(0, 4, 1), 10) +
+                      Subset(slice(4, 7, 1), 10)).list_or_slice,
+                      slice(0, 7, 1))
+        assert_equal((Subset(slice(4, 7, 1), 10) +
+                      Subset(slice(0, 4, 1), 10)).list_or_slice,
+                      slice(0, 7, 1))
+
+    def test_add_overlapping_single_step_slice_slice(self):
+        assert_equal((Subset(slice(0, 6, 1), 10) +
+                      Subset(slice(4, 7, 1), 10)).list_or_slice,
+                      slice(0, 7, 1))
+        assert_equal((Subset(slice(4, 7, 1), 10) +
+                      Subset(slice(0, 6, 1), 10)).list_or_slice,
+                      slice(0, 7, 1))
+
+    def test_adding_slice_slice_falls_back_to_list(self):
+        # If Subset can't find a way to add two slices together, it must
+        # return a list-based Subset.
+        assert_equal((Subset(slice(0, 8, 3), 20) +
+                      Subset(slice(12, 19, 2), 20)).list_or_slice,
+                      [0, 3, 6, 12, 14, 16, 18])
 
 
 @do_not_pickle_attributes("non_picklable", "bulky_attr")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,10 +132,45 @@ class TestSubset(object):
         assert_equal(Subset.safe_unsorted_fancy_index(indexable, [0, 5, 2]),
                      [0, 5, 2])
 
-    def test_raises_value_error_on_slice_producing_empty_result(self):
-        indexable = numpy.arange(10)
-        assert_raises(ValueError, Subset(slice(0, 10), 10).index_within_subset,
-                      indexable, slice(11, 13))
+    def test_list_request_sanity_check_raises_error_on_empty_list(self):
+        assert_raises(ValueError, Subset([0], 8)._list_request_sanity_check,
+                      [], 1)
+
+    def test_list_request_sanity_check_raises_error_on_negative_index(self):
+        assert_raises(ValueError, Subset([0], 8)._list_request_sanity_check,
+                      [-1], 1)
+
+    def test_list_request_sanity_check_raises_error_on_index_geq_num_ex(self):
+        assert_raises(ValueError, Subset([0], 8)._list_request_sanity_check,
+                      [1], 1)
+        assert_raises(ValueError, Subset([0], 8)._list_request_sanity_check,
+                      [2], 1)
+
+    def test_slice_request_sanity_check_raises_error_on_negative_attr(self):
+        assert_raises(ValueError, Subset([0], 8)._slice_request_sanity_check,
+                      slice(-1, None, None), 1)
+        assert_raises(ValueError, Subset([0], 8)._slice_request_sanity_check,
+                      slice(None, -1, None), 1)
+        assert_raises(ValueError, Subset([0], 8)._slice_request_sanity_check,
+                      slice(None, None, -1), 1)
+
+    def test_slice_request_sanity_check_raises_error_on_stop_gt_num_ex(self):
+        assert_raises(ValueError, Subset([0], 8)._slice_request_sanity_check,
+                      slice(None, 2), 1)
+
+    def test_slice_request_sanity_check_raises_error_on_start_geq_num_ex(self):
+        assert_raises(ValueError, Subset([0], 8)._slice_request_sanity_check,
+                      slice(1, None), 1)
+        assert_raises(ValueError, Subset([0], 8)._slice_request_sanity_check,
+                      slice(2, None), 1)
+
+    def test_slice_request_sanity_check_raises_error_on_start_geq_stop(self):
+        assert_raises(ValueError,
+                      Subset([0, 1, 2], 8)._slice_request_sanity_check,
+                      slice(1, 1), 3)
+        assert_raises(ValueError,
+                      Subset([0, 1, 2], 8)._slice_request_sanity_check,
+                      slice(2, 1), 3)
 
 
 @do_not_pickle_attributes("non_picklable", "bulky_attr")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,35 +93,35 @@ class TestSubset(object):
     def test_add_list_slice(self):
         assert_equal((Subset([0, 3, 2, 8], 10) +
                       Subset(slice(1, 9, 3), 10)).list_or_slice,
-                      [0, 1, 2, 3, 4, 7, 8])
+                     [0, 1, 2, 3, 4, 7, 8])
 
     def test_add_slice_list(self):
         assert_equal((Subset(slice(1, 9, 3), 10) +
                       Subset([0, 3, 2, 8], 10)).list_or_slice,
-                      [0, 1, 2, 3, 4, 7, 8])
+                     [0, 1, 2, 3, 4, 7, 8])
 
     def test_add_contiguous_single_step_slice_slice(self):
         assert_equal((Subset(slice(0, 4, 1), 10) +
                       Subset(slice(4, 7, 1), 10)).list_or_slice,
-                      slice(0, 7, 1))
+                     slice(0, 7, 1))
         assert_equal((Subset(slice(4, 7, 1), 10) +
                       Subset(slice(0, 4, 1), 10)).list_or_slice,
-                      slice(0, 7, 1))
+                     slice(0, 7, 1))
 
     def test_add_overlapping_single_step_slice_slice(self):
         assert_equal((Subset(slice(0, 6, 1), 10) +
                       Subset(slice(4, 7, 1), 10)).list_or_slice,
-                      slice(0, 7, 1))
+                     slice(0, 7, 1))
         assert_equal((Subset(slice(4, 7, 1), 10) +
                       Subset(slice(0, 6, 1), 10)).list_or_slice,
-                      slice(0, 7, 1))
+                     slice(0, 7, 1))
 
     def test_adding_slice_slice_falls_back_to_list(self):
         # If Subset can't find a way to add two slices together, it must
         # return a list-based Subset.
         assert_equal((Subset(slice(0, 8, 3), 20) +
                       Subset(slice(12, 19, 2), 20)).list_or_slice,
-                      [0, 3, 6, 12, 14, 16, 18])
+                     [0, 3, 6, 12, 14, 16, 18])
 
     def test_safe_unsorted_fancy_index_1(self):
         indexable = numpy.arange(10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,6 +132,11 @@ class TestSubset(object):
         assert_equal(Subset.safe_unsorted_fancy_index(indexable, [0, 5, 2]),
                      [0, 5, 2])
 
+    def test_raises_value_error_on_slice_producing_empty_result(self):
+        indexable = numpy.arange(10)
+        assert_raises(ValueError, Subset(slice(0, 10), 10).index_within_subset,
+                      indexable, slice(11, 13))
+
 
 @do_not_pickle_attributes("non_picklable", "bulky_attr")
 class DummyClass(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,13 +120,13 @@ class TestSubset(object):
                       Subset(slice(12, 16), 20)).list_or_slice,
                      [0, 1, 2, 3, 12, 13, 14, 15])
 
-    def test_safe_unsorted_fancy_index_1(self):
+    def test_safe_sorted_fancy_indexing_1(self):
         indexable = numpy.arange(10)
-        assert_equal(Subset.safe_unsorted_fancy_index(indexable, [0]), [0])
+        assert_equal(Subset.sorted_fancy_indexing(indexable, [0]), [0])
 
-    def test_safe_unsorted_fancy_index_gt_1(self):
+    def test_safe_sorted_fancy_indexing_gt_1(self):
         indexable = numpy.arange(10)
-        assert_equal(Subset.safe_unsorted_fancy_index(indexable, [0, 5, 2]),
+        assert_equal(Subset.sorted_fancy_indexing(indexable, [0, 5, 2]),
                      [0, 5, 2])
 
     def test_list_request_sanity_check_raises_error_on_empty_list(self):


### PR DESCRIPTION
Fixes #164. Fixes #244. Like suggested, I implemented a `Subset` class which factors out the logic of indexing/slicing through multiple data types, in the context of a subset of the data.

I refactored `H5PYDataset` and `IndexableDataset` to make use of `Subset`.

One of the main highlights of this implementation is that `Subset` does sanity checks on requests (e.g. making sure that a slice won't produce an empty or truncated output), which means that it would be safe to bring slices back into Fuel.

It also has the ability to merge two subsets in the most efficient way possible (e.g. two overlapping slices with step size of 1 would be merged into a single slice, as opposed to converted to a list, which is currently the case in `H5PYDataset`), and to detect when a list is a contiguous sequence and convert it into a slice. This behaviour could be expanded to accomodate more complex cases, if it's ever needed.