### PR TITLE
Fix two very nasty bugs in Merge

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -773,15 +773,16 @@ class Merge(AbstractDataStream):
             data_stream.next_epoch()
 
     def get_epoch_iterator(self, **kwargs):
-        self.next_epoch()
+        self.child_epoch_iterators = [data_stream.get_epoch_iterator()
+                                      for data_stream in self.data_streams]
         return super(Merge, self).get_epoch_iterator(**kwargs)
 
     def get_data(self, request=None):
         if request is not None:
             raise ValueError
         result = []
-        for data_stream in self.data_streams:
-            result.extend(data_stream.get_data())
+        for child_epoch_iterator in self.child_epoch_iterators:
+            result.extend(next(child_epoch_iterator))
         return tuple(result)
 
 

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -773,14 +773,16 @@ class Merge(AbstractDataStream):
             data_stream.next_epoch()
 
     def get_epoch_iterator(self, **kwargs):
+        self.next_epoch()
         return super(Merge, self).get_epoch_iterator(**kwargs)
 
     def get_data(self, request=None):
         if request is not None:
             raise ValueError
-        return sum(
-            (data_stream.get_data() for data_stream in self.data_streams),
-            tuple())
+        result = []
+        for data_stream in self.data_streams:
+            result.extend(data_stream.get_data())
+        return tuple(result)
 
 
 class BackgroundProcess(object):

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -525,8 +525,14 @@ class TestMerge(object):
         assert_equal(self.transformer.sources, ('english', 'french'))
 
     def test_merge(self):
-        assert_equal(next(self.transformer.get_epoch_iterator()),
-                     ('Hello world!', 'Bonjour le monde!'))
+        it = self.transformer.get_epoch_iterator()
+        assert_equal(next(it), ('Hello world!', 'Bonjour le monde!'))
+        assert_raises(StopIteration, next, it)
+        # There used to be problems with reseting Merge, for which
+        # reason we regression-test it as follows:
+        it = self.transformer.get_epoch_iterator()
+        assert_equal(next(it), ('Hello world!', 'Bonjour le monde!'))
+        assert_raises(StopIteration, next, it)
 
     def test_as_dict(self):
         assert_equal(

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -519,12 +519,44 @@ class TestMerge(object):
         self.streams = (
             DataStream(IterableDataset(['Hello world!'])),
             DataStream(IterableDataset(['Bonjour le monde!'])))
-        self.transformer = Merge(self.streams, ('english', 'french'))
+        self.batch_streams = (
+            Batch(DataStream(IterableDataset(['Hello world!', 'Hi!'])),
+                  iteration_scheme=ConstantScheme(2)),
+            Batch(DataStream(IterableDataset(['Bonjour le monde!', 'Salut!'])),
+                  iteration_scheme=ConstantScheme(2)))
+        self.transformer = Merge(
+            self.streams, ('english', 'french'))
+        self.batch_transformer = Merge(
+            self.batch_streams, ('english', 'french'))
 
     def test_sources(self):
         assert_equal(self.transformer.sources, ('english', 'french'))
 
     def test_merge(self):
+        it = self.transformer.get_epoch_iterator()
+        assert_equal(next(it), ('Hello world!', 'Bonjour le monde!'))
+        assert_raises(StopIteration, next, it)
+        # There used to be problems with reseting Merge, for which
+        # reason we regression-test it as follows:
+        it = self.transformer.get_epoch_iterator()
+        assert_equal(next(it), ('Hello world!', 'Bonjour le monde!'))
+        assert_raises(StopIteration, next, it)
+
+    def test_batch_merge(self):
+        it = self.batch_transformer.get_epoch_iterator()
+        assert_equal(next(it),
+                     (('Hello world!', 'Hi!'),
+                      ('Bonjour le monde!', 'Salut!')))
+        assert_raises(StopIteration, next, it)
+        # There used to be problems with reseting Merge, for which
+        # reason we regression-test it as follows:
+        it = self.batch_transformer.get_epoch_iterator()
+        assert_equal(next(it),
+                     (('Hello world!', 'Hi!'),
+                      ('Bonjour le monde!', 'Salut!')))
+        assert_raises(StopIteration, next, it)
+
+    def test_merge_batch_streams(self):
         it = self.transformer.get_epoch_iterator()
         assert_equal(next(it), ('Hello world!', 'Bonjour le monde!'))
         assert_raises(StopIteration, next, it)


### PR DESCRIPTION
The two bugs:

- when `data_stream.get_data()` raises `StopIteration` within is a generator expression, the raised exception is caught and generation stops. As a result instead of finishing the iteration the epoch iterator of `Merge` returned empty tuples. This caused the machine translation bug discussed [here](git@github.com:bartvm/fuel.git).

- `data.get_epoch_iterator()` did not reset the merged streams. Even after fixing the previous bug machine translation was not functional (crashed in the very beginning of the second epoch).

Both I and @orhanf get grade F for bug search, because the bug was perfectly reproducible with the latest Fuel. It was introduced by great Fuel interface overhaul #188, that is it was around since the beginning of July.

@heeyoulchoi, with the version of Fuel from this pull request everything seems to work well. This is however orthogonal to the data processing PR https://github.com/mila-udem/blocks-examples/pull/39, in which we still have to understand what @orhanf had in mind.