### PR TITLE
Bump the version number to 0.1.1

### DIFF
--- a/fuel/version.py
+++ b/fuel/version.py
@@ -1,1 +1,1 @@
-version = '0.0.1'
+version = '0.1.1'


### PR DESCRIPTION
Now I don't know what has happened here, but somehow the version number was not changed in Fuel before the release... let's just do it and call the result 0.1.1.