### PR TITLE
WIP: Added a transformer to segment sequences. This is useful to apply tbptt.

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -928,3 +928,77 @@ class FilterSources(AgnosticTransformer):
     def transform_any(self, data):
         return [d for d, s in izip(data, self.data_stream.sources)
                 if s in self.sources]
+
+class SegmentSequence(Transformer):
+    """Segments the sequences in a batch.
+    This transformer is useful to do tbptt. All the sequences to segment
+    should have the time dimension as their first dimension.
+    
+    Parameters
+    ----------
+    data_stream : instance of :class:`DataStream`
+        The wrapped data stream.
+    seq_size : int
+        maximum size of the resulting sequences.
+    which_sources : tuple of str, optional
+        sequences to segment
+    add_flag : bool, optional
+        add a flag indicating the beginning of a new sequence.
+    flag_name : str, optional
+        name of the source for the flag
+        
+    """
+    def __init__(self, data_stream,seq_size=100,which_sources=None,
+                 add_flag=False, flag_name = None, **kwargs):
+        super(SegmentSequence, self).__init__(data_stream=data_stream,
+            produces_examples=data_stream.produces_examples,**kwargs)
+
+        if which_sources is None:
+            which_sources = data_stream.sources
+        self.which_sources = which_sources
+
+        self.seq_size = seq_size
+        self.step = 0
+        self.data = None
+        self.len_data = None
+        self.add_flag = add_flag
+
+        if flag_name is None:
+            flag_name = u"start_flag"
+
+        self.flag_name = flag_name
+
+    @property
+    def sources(self):
+        return self.data_stream.sources + ((self.flag_name,)
+                                           if self.add_flag else ())
+
+    def get_data(self, request = None):
+        flag = 0
+
+        if self.data is None:
+            self.data = next(self.child_epoch_iterator)
+            idx = self.sources.index(self.which_sources[0])
+            self.len_data = self.data[idx].shape[0]
+            #flag is one in the first cut of sequence
+            flag = 1
+
+        segmented_data = list(self.data)
+
+        for source in self.which_sources:
+            idx = self.sources.index(source)
+            # Segment data:
+            segmented_data[idx] = self.data[idx][
+                            self.step:(self.step+self.seq_size)]
+
+        self.step += self.seq_size
+        
+        if self.step > self.len_data:
+            self.data = None
+            self.len_data = None
+            self.step = 0
+
+        if self.add_flag:
+            segmented_data.append(flag)
+
+        return tuple(segmented_data)


### PR DESCRIPTION
I coded this transformer to segment sequences. I think it can be useful for people working with RNNs. The way I use it is to segment sequences in parts and so the gradient will not have to be propagated all the way back. You can also reuse the (final) states to initialize the initial_states to have some information about the past.

Please let me know if this is useful enough to be included in fuel. If that's the case, I'll clean up the code.