### PR TITLE
repo cleanup related to releases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.rst

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ version = exec_results['version']
 
 setup(
     name='fuel',
-    version='0.1.1',
+    version=version,  # PEP 440 compliant
     description='Data pipeline framework for machine learning',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/mila-udem/fuel.git',
-    downlaod_url='https://github.com/mila-udem/fuel/archive/v0.1.1.tar.gz',
+    download_url='https://github.com/mila-udem/fuel/tarball/v' + version,
     author='Universite de Montreal',
     license='MIT',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ version = exec_results['version']
 
 setup(
     name='fuel',
-    version=version,  # PEP 440 compliant
+    version='0.1.1',
     description='Data pipeline framework for machine learning',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/mila-udem/fuel.git',
+    downlaod_url='https://github.com/mila-udem/fuel/archive/v0.1.1.tar.gz',
     author='Universite de Montreal',
     license='MIT',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
I did some housekeeping I thought it might be useful to offer back:

 1. Merged in previous releases to master so that they would be upstream of master
 2. Updated setup.py and added setup.cfg to support PyPI release (#275)
 3. Added git annotated tags for releases since the repo had only lightweight tags

Note that any of the above can be taken independently.

for 1 and 2, merge this pull request
for 1 only, merge 1f22757
for 2 only, cherry-pick af9488c
3 is independent of 1,2 but could be done by fetching and pushing my repo's annotated tags

Just wanted to offer this work back - not offended if you decide to close and not pull this into master.