### PR TITLE
Fix ensure_directory_exists test

### DIFF
--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -87,7 +87,7 @@ def test_ensure_directory_exists():
     with open(filepath, 'w') as f:
         f.write(' ')
 
-    assert_raises(ensure_directory_exists(filepath))
+    assert_raises(OSError, ensure_directory_exists(filepath))
 
     shutil.rmtree(dirpath, ignore_errors=True)
 


### PR DESCRIPTION
On my system this failed with the sensible error:

```
======================================================================
ERROR: tests.test_downloaders.test_ensure_directory_exists
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vanmerb/anaconda3/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/vanmerb/fuel/tests/test_downloaders.py", line 90, in test_ensure_directory_exists
    assert_raises(ensure_directory_exists(filepath))
  File "/home/vanmerb/anaconda3/lib/python3.5/site-packages/numpy/testing/utils.py", line 1109, in assert_raises
    return nose.tools.assert_raises(*args,**kwargs)
  File "/home/vanmerb/anaconda3/lib/python3.5/unittest/case.py", line 727, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/home/vanmerb/anaconda3/lib/python3.5/unittest/case.py", line 157, in handle
    (name, self._base_type_str))
TypeError: assertRaises() arg 1 must be an exception type or tuple of exception types
```

Why this was passing on Travis is a mystery to me.