### PR TITLE
Add YouTube audio dataset

### DIFF
--- a/fuel/converters/__init__.py
+++ b/fuel/converters/__init__.py
@@ -20,6 +20,7 @@ from fuel.converters import iris
 from fuel.converters import mnist
 from fuel.converters import svhn
 from fuel.converters import ilsvrc2010
+from fuel.converters import youtube_audio
 
 __version__ = '0.2'
 all_converters = (
@@ -32,4 +33,5 @@ all_converters = (
     ('iris', iris.fill_subparser),
     ('mnist', mnist.fill_subparser),
     ('svhn', svhn.fill_subparser),
-    ('ilsvrc2010', ilsvrc2010.fill_subparser))
+    ('ilsvrc2010', ilsvrc2010.fill_subparser),
+    ('youtube_audio', youtube_audio.fill_subparser))

--- a/fuel/converters/youtube_audio.py
+++ b/fuel/converters/youtube_audio.py
@@ -1,0 +1,50 @@
+import os
+
+import h5py
+import scipy.io.wavfile
+
+from fuel.converters.base import fill_hdf5_file
+
+
+def convert_youtube_audio(directory, output_directory, youtube_id, channels,
+                          sample, output_filename=None):
+    input_file = os.path.join(directory, '{}.m4a'.format(youtube_id))
+    wav_filename = '{}.wav'.format(youtube_id)
+    wav_file = os.path.join(directory, wav_filename)
+    command = "ffmpeg -y -i {} -ac {} -ar {} {}".format(
+            input_file, channels, sample, wav_file)
+    os.system(command)
+
+    # Load WAV into array
+    _, data = scipy.io.wavfile.read(wav_file)
+    if data.ndim == 1:
+        data = data[:, None]
+
+    # Store in HDF5
+    if output_filename is None:
+        output_filename = '{}.hdf5'.format(youtube_id)
+    output_file = os.path.join(output_directory, output_filename)
+
+    with h5py.File(output_file, 'w') as h5file:
+        fill_hdf5_file(h5file, (('train', 'features', data),))
+        h5file['features'].dims[0].label = 'time'
+        h5file['features'].dims[1].label = 'feature'
+
+    return (output_file,)
+
+
+def fill_subparser(subparser):
+    subparser.add_argument(
+        '--youtube-id', type=str, required=True,
+        help=("The YouTube ID of the video from which to extract audio, "
+              "usually an 11-character string.")
+    )
+    subparser.add_argument(
+        '--channels', type=int, default=1,
+        help="The number of audio channels to convert to"
+    )
+    subparser.add_argument(
+        '--sample', type=int, default=16000,
+        help="The sampling rate in Hz"
+    )
+    return convert_youtube_audio

--- a/fuel/converters/youtube_audio.py
+++ b/fuel/converters/youtube_audio.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 
 import h5py
 import scipy.io.wavfile
@@ -8,17 +10,43 @@ from fuel.converters.base import fill_hdf5_file
 
 def convert_youtube_audio(directory, output_directory, youtube_id, channels,
                           sample, output_filename=None):
+    """Converts downloaded YouTube audio to HDF5 format.
+
+    Requires `ffmpeg` to be installed and available on the command line
+    (i.e. available on your `PATH`).
+
+    Parameters
+    ----------
+    directory : str
+        Directory in which input files reside.
+    output_directory : str
+        Directory in which to save the converted dataset.
+    youtube_id : str
+        11-character video ID (taken from YouTube URL)
+    channels : int
+        The number of audio channels to use in the PCM Wave file.
+    sample : int
+        The sampling rate to use in Hz, e.g. 44100 or 16000.
+    output_filename : str, optional
+        Name of the saved dataset. If `None` (the default), `youtube_id.hdf5`
+        is used.
+
+    """
     input_file = os.path.join(directory, '{}.m4a'.format(youtube_id))
     wav_filename = '{}.wav'.format(youtube_id)
     wav_file = os.path.join(directory, wav_filename)
-    command = "ffmpeg -y -i {} -ac {} -ar {} {}".format(
-            input_file, channels, sample, wav_file)
-    os.system(command)
+    ffmpeg_not_available = subprocess.call(['ffmpeg', '-version'])
+    if ffmpeg_not_available:
+        raise RuntimeError('conversion requires ffmpeg')
+    subprocess.check_call(['ffmpeg', '-y', '-i', input_file, '-ac',
+                           str(channels), '-ar', str(sample), wav_file],
+                          stdout=sys.stdout)
 
     # Load WAV into array
     _, data = scipy.io.wavfile.read(wav_file)
     if data.ndim == 1:
         data = data[:, None]
+    data = data[None, :]
 
     # Store in HDF5
     if output_filename is None:
@@ -27,13 +55,25 @@ def convert_youtube_audio(directory, output_directory, youtube_id, channels,
 
     with h5py.File(output_file, 'w') as h5file:
         fill_hdf5_file(h5file, (('train', 'features', data),))
-        h5file['features'].dims[0].label = 'time'
-        h5file['features'].dims[1].label = 'feature'
+        h5file['features'].dims[0].label = 'batch'
+        h5file['features'].dims[1].label = 'time'
+        h5file['features'].dims[2].label = 'feature'
 
     return (output_file,)
 
 
 def fill_subparser(subparser):
+    """Sets up a subparser to convert YouTube audio files.
+
+    Adds the compulsory `--youtube-id` flag as well as the optional
+    `sample` and `channels` flags.
+
+    Parameters
+    ----------
+    subparser : :class:`argparse.ArgumentParser`
+        Subparser handling the `youtube_audio` command.
+
+    """
     subparser.add_argument(
         '--youtube-id', type=str, required=True,
         help=("The YouTube ID of the video from which to extract audio, "
@@ -41,10 +81,13 @@ def fill_subparser(subparser):
     )
     subparser.add_argument(
         '--channels', type=int, default=1,
-        help="The number of audio channels to convert to"
+        help=("The number of audio channels to convert to. The default of 1"
+              "means audio is converted to mono.")
     )
     subparser.add_argument(
         '--sample', type=int, default=16000,
-        help="The sampling rate in Hz"
+        help=("The sampling rate in Hz. The default of 16000 is "
+              "significantly downsampled compared to normal WAVE files; "
+              "pass 44100 for the usual sampling rate.")
     )
     return convert_youtube_audio

--- a/fuel/datasets/youtube_audio.py
+++ b/fuel/datasets/youtube_audio.py
@@ -3,6 +3,24 @@ from fuel.utils import find_in_data_path
 
 
 class YouTubeAudio(H5PYDataset):
+    """Dataset of audio from YouTube video.
+
+    Assumes the existence of a dataset file with the name
+    `youtube_id.hdf5`. These datasets don't have any split; the entire
+    audio sequence is considered training.
+
+    Note that the data structured in the form `(batch, time, features)`
+    where `features` are the audio channels (dimension 1 or 2) and batch is
+    equal to 1 in this case (since there is only one audiotrack).
+
+    Parameters
+    ----------
+    youtube_id : str
+        11-character video ID (taken from YouTube URL)
+    \*\*kwargs
+        Passed to the `H5PYDataset` class.
+
+    """
     def __init__(self, youtube_id, **kwargs):
         super(YouTubeAudio, self).__init__(
             file_or_path=find_in_data_path('{}.hdf5'.format(youtube_id)),

--- a/fuel/datasets/youtube_audio.py
+++ b/fuel/datasets/youtube_audio.py
@@ -1,0 +1,10 @@
+from fuel.datasets.hdf5 import H5PYDataset
+from fuel.utils import find_in_data_path
+
+
+class YouTubeAudio(H5PYDataset):
+    def __init__(self, youtube_id, **kwargs):
+        super(YouTubeAudio, self).__init__(
+            file_or_path=find_in_data_path('{}.hdf5'.format(youtube_id)),
+            which_sets=('train',), **kwargs
+        )

--- a/fuel/downloaders/__init__.py
+++ b/fuel/downloaders/__init__.py
@@ -16,6 +16,7 @@ from fuel.downloaders import iris
 from fuel.downloaders import mnist
 from fuel.downloaders import svhn
 from fuel.downloaders import ilsvrc2010
+from fuel.downloaders import youtube_audio
 
 all_downloaders = (
     ('adult', adult.fill_subparser),
@@ -27,4 +28,5 @@ all_downloaders = (
     ('mnist', mnist.fill_subparser),
     ('svhn', svhn.fill_subparser),
     ('ilsvrc2010', ilsvrc2010.fill_subparser),
-    ('dogs_vs_cats', dogs_vs_cats.fill_subparser))
+    ('dogs_vs_cats', dogs_vs_cats.fill_subparser),
+    ('youtube_audio', youtube_audio.fill_subparser))

--- a/fuel/downloaders/youtube_audio.py
+++ b/fuel/downloaders/youtube_audio.py
@@ -1,3 +1,5 @@
+import os
+
 try:
     import pafy
     PAFY_AVAILABLE = True
@@ -6,16 +8,47 @@ except ImportError:
 
 
 def download(directory, youtube_id, clear=False):
+    """Download the audio of a YouTube video.
+
+    The audio is downloaded in the highest available quality. Progress is
+    printed to `stdout`. The file is named `youtube_id.m4a`, where
+    `youtube_id` is the 11-character code identifiying the YouTube video
+    (can be determined from the URL).
+
+    Parameters
+    ----------
+    directory : str
+        The directory in which to save the downloaded audio file.
+    youtube_id : str
+        11-character video ID (taken from YouTube URL)
+    clear : bool
+        If `True`, it deletes the downloaded video. Otherwise it downloads
+        it. Defaults to `False`.
+
+    """
+    filepath = os.path.join(directory, '{}.m4a'.format(youtube_id))
+    if clear:
+        os.remove(filepath)
+        return
     if not PAFY_AVAILABLE:
         raise ImportError("pafy is required to download YouTube videos")
     url = 'https://www.youtube.com/watch?v={}'.format(youtube_id)
     video = pafy.new(url)
     audio = video.getbestaudio()
-    filepath = '{}.m4a'.format(youtube_id)
     audio.download(quiet=False, filepath=filepath)
 
 
 def fill_subparser(subparser):
+    """Sets up a subparser to download audio of YouTube videos.
+
+    Adds the compulsory `--youtube-id` flag.
+
+    Parameters
+    ----------
+    subparser : :class:`argparse.ArgumentParser`
+        Subparser handling the `youtube_audio` command.
+
+    """
     subparser.add_argument(
         '--youtube-id', type=str, required=True,
         help=("The YouTube ID of the video from which to extract audio, "

--- a/fuel/downloaders/youtube_audio.py
+++ b/fuel/downloaders/youtube_audio.py
@@ -1,0 +1,24 @@
+try:
+    import pafy
+    PAFY_AVAILABLE = True
+except ImportError:
+    PAFY_AVAILABLE = False
+
+
+def download(directory, youtube_id, clear=False):
+    if not PAFY_AVAILABLE:
+        raise ImportError("pafy is required to download YouTube videos")
+    url = 'https://www.youtube.com/watch?v={}'.format(youtube_id)
+    video = pafy.new(url)
+    audio = video.getbestaudio()
+    filepath = '{}.m4a'.format(youtube_id)
+    audio.download(quiet=False, filepath=filepath)
+
+
+def fill_subparser(subparser):
+    subparser.add_argument(
+        '--youtube-id', type=str, required=True,
+        help=("The YouTube ID of the video from which to extract audio, "
+              "usually an 11-character string.")
+    )
+    return download


### PR DESCRIPTION
@sotelo

Allows you to download audio from a YouTube video, convert to .wav format and save in HDF5 e.g.

```bash
fuel-download youtube_audio --youtube-id XqaJ2Ol5cC4
fuel-convert youtube_audio --youtube-id XqaJ2Ol5cC4
```
```python
from fuel.datasets.youtube_audio import YouTubeAudio
dataset = YouTubeAudio('XqaJ2Ol5cC4')
```

Requiers the Python `pafy` module for downloading, and `ffmpeg` for converting.