### PR TITLE
Support for list of same-length examples

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -359,7 +359,7 @@ class Flatten(SourcewiseTransformer):
         return numpy.asarray(source_example).flatten()
 
     def transform_source_batch(self, source_batch, _):
-        return numpy.asarray(source_batch).reshape((source_batch.shape[0], -1))
+        return numpy.asarray(source_batch).reshape((len(source_batch), -1))
 
 
 class ScaleAndShift(AgnosticSourcewiseTransformer):


### PR DESCRIPTION
Right now `Flatten` chokes when you feed it a list of identically sized arrays (as output by e.g. `RandomFixedSizeCrop` and `MinimumImageSize`. Using `len` instead of `.shape[0]` should support both cases (list and NumPy array).