### PR TITLE
UTF-8 and Gzip for text files

### DIFF
--- a/fuel/converters/youtube_audio.py
+++ b/fuel/converters/youtube_audio.py
@@ -28,8 +28,8 @@ def convert_youtube_audio(directory, output_directory, youtube_id, channels,
     sample : int
         The sampling rate to use in Hz, e.g. 44100 or 16000.
     output_filename : str, optional
-        Name of the saved dataset. If `None` (the default), `youtube_id.hdf5`
-        is used.
+        Name of the saved dataset. If `None` (the default),
+        `youtube_id.hdf5` is used.
 
     """
     input_file = os.path.join(directory, '{}.m4a'.format(youtube_id))

--- a/fuel/datasets/text.py
+++ b/fuel/datasets/text.py
@@ -13,7 +13,7 @@ class TextFile(Dataset):
         The names of the files in order which they should be read. Each
         file is expected to have a sentence per line. If the filename ends
         with `.gz` it will be opened using `gzip`. Note however that `gzip`
-        file handles aren't picklable on Python 2.
+        file handles aren't picklable on legacy Python.
     dictionary : str or dict
         Either the path to a Pickled dictionary mapping tokens to integers,
         or the dictionary itself. At the very least this dictionary must

--- a/fuel/datasets/text.py
+++ b/fuel/datasets/text.py
@@ -1,6 +1,7 @@
 from picklable_itertools import iter_, chain
 
 from fuel.datasets import Dataset
+from fuel.utils.formats import open_
 
 
 class TextFile(Dataset):
@@ -10,7 +11,9 @@ class TextFile(Dataset):
     ----------
     files : list of str
         The names of the files in order which they should be read. Each
-        file is expected to have a sentence per line.
+        file is expected to have a sentence per line. If the filename ends
+        with `.gz` it will be opened using `gzip`. Note however that `gzip`
+        file handles aren't picklable on Python 2.
     dictionary : str or dict
         Either the path to a Pickled dictionary mapping tokens to integers,
         or the dictionary itself. At the very least this dictionary must
@@ -24,7 +27,7 @@ class TextFile(Dataset):
         ``bos_taken``.
     unk_token : str, optional
         The token in the dictionary to fall back on when a token could not
-        be found in the dictionary.
+        be found in the dictionary. ``<UNK>`` by default.
     level : 'word' or 'character', optional
         If 'word' the dictionary is expected to contain full words. The
         sentences in the text file will be split at the spaces, and each
@@ -32,11 +35,16 @@ class TextFile(Dataset):
         in each example being a single list of numbers. If 'character' the
         dictionary is expected to contain single letters as keys. A single
         example will be a list of character numbers, starting with the
-        first non-whitespace character and finishing with the last one.
+        first non-whitespace character and finishing with the last one. The
+        default is 'word'.
     preprocess : function, optional
         A function which takes a sentence (string) as an input and returns
         a modified string. For example ``str.lower`` in order to lowercase
         the sentence before numberizing.
+    encoding : str, optional
+        The encoding to use to read the file. Defaults to ``None``. Use
+        UTF-8 if the dictionary you pass contains UTF-8 characters, but
+        note that this makes the dataset unpicklable on legacy Python.
 
     Examples
     --------
@@ -66,7 +74,8 @@ class TextFile(Dataset):
     example_iteration_scheme = None
 
     def __init__(self, files, dictionary, bos_token='<S>', eos_token='</S>',
-                 unk_token='<UNK>', level='word', preprocess=None):
+                 unk_token='<UNK>', level='word', preprocess=None,
+                 encoding=None):
         self.files = files
         self.dictionary = dictionary
         if bos_token is not None and bos_token not in dictionary:
@@ -82,10 +91,12 @@ class TextFile(Dataset):
             raise ValueError
         self.level = level
         self.preprocess = preprocess
+        self.encoding = encoding
         super(TextFile, self).__init__()
 
     def open(self):
-        return chain(*[iter_(open(f)) for f in self.files])
+        return chain(*[iter_(open_(f, encoding=self.encoding))
+                       for f in self.files])
 
     def get_data(self, state=None, request=None):
         if request is not None:

--- a/fuel/datasets/youtube_audio.py
+++ b/fuel/datasets/youtube_audio.py
@@ -3,7 +3,7 @@ from fuel.utils import find_in_data_path
 
 
 class YouTubeAudio(H5PYDataset):
-    """Dataset of audio from YouTube video.
+    r"""Dataset of audio from YouTube video.
 
     Assumes the existence of a dataset file with the name
     `youtube_id.hdf5`. These datasets don't have any split; the entire

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -108,8 +108,8 @@ class AbstractDataStream(object):
         However, this behavior only works as long as the ``epochs``
         property is iterated over using e.g. ``for epoch in
         stream.epochs``. If you create the data iterators in advance (e.g.
-        using ``for i, epoch in zip(range(10), stream.epochs`` in Python 2)
-        you must call the :meth:`reset` method yourself.
+        using ``for i, epoch in zip(range(10), stream.epochs`` in legacy
+        Python) you must call the :meth:`reset` method yourself.
 
         """
         while True:

--- a/fuel/transformers/image.py
+++ b/fuel/transformers/image.py
@@ -21,10 +21,10 @@ class ImagesFromBytes(SourcewiseTransformer):
     Parameters
     ----------
     data_stream : instance of :class:`AbstractDataStream`
-        The wrapped data stream. The individual examples returned by
-        this should be the bytes (in a `bytes` container on Python 3
-        or a `str` on Python 2) comprising an image in a format readable
-        by PIL, such as PNG, JPEG, etc.
+        The wrapped data stream. The individual examples returned by this
+        should be the bytes (in a `bytes` container, or a `str` on legacy
+        Python) comprising an image in a format readable by PIL, such as
+        PNG, JPEG, etc.
     color_mode : str, optional
         Mode to pass to PIL for color space conversion. Default is RGB.
         If `None`, no coercion is performed.
@@ -40,9 +40,9 @@ class ImagesFromBytes(SourcewiseTransformer):
     the sake of uniformity/predictability.
 
     This SourcewiseTransformer supports streams returning single examples
-    as `bytes` objects (`str` on Python 2.x) as well as streams that
-    return iterables containing such objects. In the case of an
-    iterable, a list of loaded images is returned.
+    as `bytes` objects (`str` on legacy Python) as well as streams that
+    return iterables containing such objects. In the case of an iterable, a
+    list of loaded images is returned.
 
     """
     def __init__(self, data_stream, color_mode='RGB', **kwargs):

--- a/fuel/utils/formats.py
+++ b/fuel/utils/formats.py
@@ -1,6 +1,48 @@
 """Low-level utilities for reading a variety of source formats."""
+import codecs
+import gzip
+import io
 import tarfile
 import six
+
+
+def open_(filename, mode='r', encoding=None):
+    """Open a text file with encoding and optional gzip compression.
+
+    Note that on legacy Python any encoding other than ``None`` or opening
+    GZipped files will return an unpicklable file-like object.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to read.
+    mode : str, optional
+        The mode with which to open the file. Defaults to `r`.
+    encoding : str, optional
+        The encoding to use (see the codecs documentation_ for supported
+        values). Defaults to ``None``.
+
+    .. _documentation:
+    https://docs.python.org/3/library/codecs.html#standard-encodings
+
+    """
+    if filename.endswith('.gz'):
+        if six.PY2:
+            zf = io.BufferedReader(gzip.open(filename, mode))
+            if encoding:
+                return codecs.getreader(encoding)(zf)
+            else:
+                return zf
+        else:
+            return io.BufferedReader(gzip.open(filename, mode,
+                                               encoding=encoding))
+    if six.PY2:
+        if encoding:
+            return codecs.open(filename, mode, encoding=encoding)
+        else:
+            return open(filename, mode)
+    else:
+        return open(filename, mode, encoding=encoding)
 
 
 def tar_open(f):


### PR DESCRIPTION
Adds a helper function to open text files which ensures UTF-8 encoding
is used in Python 2, and allows the user to pass files with Gzip
compression (which can be faster as well as more space efficient on
disk).