### PR TITLE
ilsvrc2012 dataset

### DIFF
--- a/fuel/converters/__init__.py
+++ b/fuel/converters/__init__.py
@@ -21,6 +21,7 @@ from fuel.converters import iris
 from fuel.converters import mnist
 from fuel.converters import svhn
 from fuel.converters import ilsvrc2010
+from fuel.converters import ilsvrc2012
 from fuel.converters import youtube_audio
 
 __version__ = '0.2'
@@ -36,4 +37,5 @@ all_converters = (
     ('mnist', mnist.fill_subparser),
     ('svhn', svhn.fill_subparser),
     ('ilsvrc2010', ilsvrc2010.fill_subparser),
+    ('ilsvrc2012', ilsvrc2012.fill_subparser),
     ('youtube_audio', youtube_audio.fill_subparser))

--- a/fuel/converters/ilsvrc2010.py
+++ b/fuel/converters/ilsvrc2010.py
@@ -236,7 +236,8 @@ def _write_to_hdf5(hdf5_file, index, image_filename, image_data,
                    class_index):
     hdf5_file['filenames'][index] = image_filename.encode('ascii')
     hdf5_file['encoded_images'][index] = image_data
-    hdf5_file['targets'][index] = class_index
+    if class_index is not None:
+        hdf5_file['targets'][index] = class_index
 
 
 def train_set_producer(socket, train_archive, patch_archive, wnid_map):

--- a/fuel/converters/ilsvrc2012.py
+++ b/fuel/converters/ilsvrc2012.py
@@ -1,0 +1,572 @@
+from __future__ import division
+from collections import OrderedDict
+from functools import partial
+import gzip
+import io
+import os
+import logging
+import os.path
+
+import h5py
+import numpy
+from picklable_itertools.extras import equizip
+from PIL import Image
+from scipy.io.matlab import loadmat
+from six.moves import zip, xrange
+import zmq
+
+from fuel.converters.base import check_exists, progress_bar
+from fuel.datasets import H5PYDataset
+from fuel.utils.formats import tar_open
+from fuel.utils.parallel import producer_consumer
+from fuel import config
+
+log = logging.getLogger(__name__)
+
+DEVKIT_ARCHIVE = 'ILSVRC2010_devkit-1.0.tar.gz'
+DEVKIT_META_PATH = 'devkit-1.0/data/meta.mat'
+DEVKIT_VALID_GROUNDTRUTH_PATH = ('devkit-1.0/data/'
+                                 'ILSVRC2010_validation_ground_truth.txt')
+PATCH_IMAGES_TAR = 'patch_images.tar'
+TEST_GROUNDTRUTH = 'ILSVRC2010_test_ground_truth.txt'
+TRAIN_IMAGES_TAR = 'ILSVRC2010_images_train.tar'
+VALID_IMAGES_TAR = 'ILSVRC2010_images_val.tar'
+TEST_IMAGES_TAR = 'ILSVRC2010_images_test.tar'
+IMAGE_TARS = (TRAIN_IMAGES_TAR, VALID_IMAGES_TAR, TEST_IMAGES_TAR,
+              PATCH_IMAGES_TAR)
+PUBLIC_FILES = TEST_GROUNDTRUTH, DEVKIT_ARCHIVE
+ALL_FILES = PUBLIC_FILES + IMAGE_TARS
+
+
+@check_exists(required_files=ALL_FILES)
+def convert_ilsvrc2010(directory, output_directory,
+                       output_filename='ilsvrc2010.hdf5',
+                       shuffle_seed=config.default_seed):
+    """Converter for data from the ILSVRC 2010 competition.
+
+    Source files for this dataset can be obtained by registering at
+    [ILSVRC2010WEB].
+
+    Parameters
+    ----------
+    input_directory : str
+        Path from which to read raw data files.
+    output_directory : str
+        Path to which to save the HDF5 file.
+    output_filename : str, optional
+        The output filename for the HDF5 file. Default: 'ilsvrc2010.hdf5'.
+    shuffle_seed : int or sequence, optional
+        Seed for a random number generator used to shuffle the order
+        of the training set on disk, so that sequential reads will not
+        be ordered by class.
+
+    .. [ILSVRC2010WEB] http://image-net.org/challenges/LSVRC/2010/index
+
+    """
+    devkit_path = os.path.join(directory, DEVKIT_ARCHIVE)
+    test_groundtruth_path = os.path.join(directory, TEST_GROUNDTRUTH)
+    train, valid, test, patch = [os.path.join(directory, fn)
+                                 for fn in IMAGE_TARS]
+    n_train, valid_groundtruth, test_groundtruth, wnid_map = \
+        prepare_metadata(devkit_path, test_groundtruth_path)
+    n_valid, n_test = len(valid_groundtruth), len(test_groundtruth)
+    output_path = os.path.join(output_directory, output_filename)
+
+    with h5py.File(output_path, 'w') as f:
+        log.info('Creating HDF5 datasets...')
+        prepare_hdf5_file(f, n_train, n_valid, n_test)
+        log.info('Processing training set...')
+        process_train_set(f, train, patch, n_train, wnid_map, shuffle_seed)
+        log.info('Processing validation set...')
+        process_other_set(f, 'valid', valid, patch, valid_groundtruth, n_train)
+        log.info('Processing test set...')
+        process_other_set(f, 'test', test, patch, test_groundtruth,
+                          n_train + n_valid)
+        log.info('Done.')
+
+    return (output_path,)
+
+
+def fill_subparser(subparser):
+    """Sets up a subparser to convert the ILSVRC2010 dataset files.
+
+    Parameters
+    ----------
+    subparser : :class:`argparse.ArgumentParser`
+        Subparser handling the `ilsvrc2010` command.
+
+    """
+    subparser.add_argument(
+        "--shuffle-seed", help="Seed to use for randomizing order of the "
+                               "training set on disk.",
+        default=config.default_seed, type=int, required=False)
+    return convert_ilsvrc2010
+
+
+def prepare_metadata(devkit_archive, test_groundtruth_path):
+    """Extract dataset metadata required for HDF5 file setup.
+
+    Parameters
+    ----------
+    devkit_archive : str or file-like object
+        The filename or file-handle for the gzipped TAR archive
+        containing the ILSVRC2010 development kit.
+    test_groundtruth_path : str or file-like object
+        The filename or file-handle for the text file containing
+        the ILSVRC2010 test set ground truth.
+
+    Returns
+    -------
+    n_train : int
+        The number of examples in the training set.
+    valid_groundtruth : ndarray, 1-dimensional
+        An ndarray containing the validation set groundtruth in terms of
+        0-based class indices.
+    test_groundtruth : ndarray, 1-dimensional
+        An ndarray containing the test groundtruth in terms of 0-based
+        class indices.
+    wnid_map : dict
+        A dictionary that maps WordNet IDs to 0-based class indices.
+
+    """
+    # Read what's necessary from the development kit.
+    synsets, cost_matrix, raw_valid_groundtruth = read_devkit(devkit_archive)
+
+    # Mapping to take WordNet IDs to our internal 0-999 encoding.
+    wnid_map = dict(zip((s.decode('utf8') for s in synsets['WNID']),
+                        xrange(1000)))
+
+    # Map the 'ILSVRC2010 ID' to our zero-based ID.
+    ilsvrc_id_to_zero_based = dict(zip(synsets['ILSVRC2010_ID'],
+                                   xrange(len(synsets))))
+
+    # Map the validation set groundtruth to 0-999 labels.
+    valid_groundtruth = [ilsvrc_id_to_zero_based[id_]
+                         for id_ in raw_valid_groundtruth]
+
+    # Raw test data groundtruth, ILSVRC2010 IDs.
+    raw_test_groundtruth = numpy.loadtxt(test_groundtruth_path,
+                                         dtype=numpy.int16)
+
+    # Map the test set groundtruth to 0-999 labels.
+    test_groundtruth = [ilsvrc_id_to_zero_based[id_]
+                        for id_ in raw_test_groundtruth]
+
+    # Ascertain the number of filenames to prepare appropriate sized
+    # arrays.
+    n_train = int(synsets['num_train_images'].sum())
+    log.info('Training set: {} images'.format(n_train))
+    log.info('Validation set: {} images'.format(len(valid_groundtruth)))
+    log.info('Test set: {} images'.format(len(test_groundtruth)))
+    n_total = n_train + len(valid_groundtruth) + len(test_groundtruth)
+    log.info('Total (train/valid/test): {} images'.format(n_total))
+    return n_train, valid_groundtruth, test_groundtruth, wnid_map
+
+
+def create_splits(n_train, n_valid, n_test):
+    n_total = n_train + n_valid + n_test
+    tuples = {}
+    tuples['train'] = (0, n_train)
+    tuples['valid'] = (n_train, n_train + n_valid)
+    tuples['test'] = (n_train + n_valid, n_total)
+    sources = ['encoded_images', 'targets', 'filenames']
+    return OrderedDict(
+        (split, OrderedDict((source, tuples[split]) for source in sources))
+        for split in ('train', 'valid', 'test')
+    )
+
+
+def prepare_hdf5_file(hdf5_file, n_train, n_valid, n_test):
+    """Create datasets within a given HDF5 file.
+
+    Parameters
+    ----------
+    hdf5_file : :class:`h5py.File` instance
+        HDF5 file handle to which to write.
+    n_train : int
+        The number of training set examples.
+    n_valid : int
+        The number of validation set examples.
+    n_test : int
+        The number of test set examples.
+
+    """
+    n_total = n_train + n_valid + n_test
+    splits = create_splits(n_train, n_valid, n_test)
+    hdf5_file.attrs['split'] = H5PYDataset.create_split_array(splits)
+    vlen_dtype = h5py.special_dtype(vlen=numpy.dtype('uint8'))
+    hdf5_file.create_dataset('encoded_images', shape=(n_total,),
+                             dtype=vlen_dtype)
+    hdf5_file.create_dataset('targets', shape=(n_total, 1), dtype=numpy.int16)
+    hdf5_file.create_dataset('filenames', shape=(n_total, 1), dtype='S32')
+
+
+def process_train_set(hdf5_file, train_archive, patch_archive, n_train,
+                      wnid_map, shuffle_seed=None):
+    """Process the ILSVRC2010 training set.
+
+    Parameters
+    ----------
+    hdf5_file : :class:`h5py.File` instance
+        HDF5 file handle to which to write. Assumes `features`, `targets`
+        and `filenames` already exist and have first dimension larger than
+        `n_train`.
+    train_archive :  str or file-like object
+        Filename or file handle for the TAR archive of training images.
+    patch_archive :  str or file-like object
+        Filename or file handle for the TAR archive of patch images.
+    n_train : int
+        The number of items in the training set.
+    wnid_map : dict
+        A dictionary mapping WordNet IDs to class indices.
+    shuffle_seed : int or sequence, optional
+        Seed for a NumPy random number generator that permutes the
+        training set on disk. If `None`, no permutation is performed
+        (this is the default).
+
+    """
+    producer = partial(train_set_producer, train_archive=train_archive,
+                       patch_archive=patch_archive, wnid_map=wnid_map)
+    consumer = partial(image_consumer, hdf5_file=hdf5_file,
+                       num_expected=n_train, shuffle_seed=shuffle_seed)
+    producer_consumer(producer, consumer)
+
+
+def _write_to_hdf5(hdf5_file, index, image_filename, image_data,
+                   class_index):
+    hdf5_file['filenames'][index] = image_filename.encode('ascii')
+    hdf5_file['encoded_images'][index] = image_data
+    hdf5_file['targets'][index] = class_index
+
+
+def train_set_producer(socket, train_archive, patch_archive, wnid_map):
+    """Load/send images from the training set TAR file or patch images.
+
+    Parameters
+    ----------
+    socket : :class:`zmq.Socket`
+        PUSH socket on which to send loaded images.
+    train_archive :  str or file-like object
+        Filename or file handle for the TAR archive of training images.
+    patch_archive :  str or file-like object
+        Filename or file handle for the TAR archive of patch images.
+    wnid_map : dict
+        A dictionary that maps WordNet IDs to 0-based class indices.
+        Used to decode the filenames of the inner TAR files.
+
+    """
+    patch_images = extract_patch_images(patch_archive, 'train')
+    num_patched = 0
+    with tar_open(train_archive) as tar:
+        for inner_tar_info in tar:
+            with tar_open(tar.extractfile(inner_tar_info.name)) as inner:
+                wnid = inner_tar_info.name.split('.')[0]
+                class_index = wnid_map[wnid]
+                filenames = sorted(info.name for info in inner
+                                   if info.isfile())
+                images_gen = (load_from_tar_or_patch(inner, filename,
+                                                     patch_images)
+                              for filename in filenames)
+                pathless_filenames = (os.path.split(fn)[-1]
+                                      for fn in filenames)
+                stream = equizip(pathless_filenames, images_gen)
+                for image_fn, (image_data, patched) in stream:
+                    if patched:
+                        num_patched += 1
+                    socket.send_pyobj((image_fn, class_index), zmq.SNDMORE)
+                    socket.send(image_data)
+    if num_patched != len(patch_images):
+        raise ValueError('not all patch images were used')
+
+
+def image_consumer(socket, hdf5_file, num_expected, shuffle_seed=None,
+                   offset=0):
+    """Fill an HDF5 file with incoming images from a socket.
+
+    Parameters
+    ----------
+    socket : :class:`zmq.Socket`
+        PULL socket on which to receive images.
+    hdf5_file : :class:`h5py.File` instance
+        HDF5 file handle to which to write. Assumes `features`, `targets`
+        and `filenames` already exist and have first dimension larger than
+        `sum(images_per_class)`.
+    num_expected : int
+        The number of items we expect to be sent over the socket.
+    shuffle_seed : int or sequence, optional
+        Seed for a NumPy random number generator that permutes the
+        images on disk.
+    offset : int, optional
+        The offset in the HDF5 datasets at which to start writing
+        received examples. Defaults to 0.
+
+    """
+    with progress_bar('images', maxval=num_expected) as pb:
+        if shuffle_seed is None:
+            index_gen = iter(xrange(num_expected))
+        else:
+            rng = numpy.random.RandomState(shuffle_seed)
+            index_gen = iter(rng.permutation(num_expected))
+        for i, num in enumerate(index_gen):
+            image_filename, class_index = socket.recv_pyobj(zmq.SNDMORE)
+            image_data = numpy.fromstring(socket.recv(), dtype='uint8')
+            _write_to_hdf5(hdf5_file, num + offset, image_filename,
+                           image_data, class_index)
+            pb.update(i + 1)
+
+
+def process_other_set(hdf5_file, which_set, image_archive, patch_archive,
+                      groundtruth, offset):
+    """Process the validation or test set.
+
+    Parameters
+    ----------
+    hdf5_file : :class:`h5py.File` instance
+        HDF5 file handle to which to write. Assumes `features`, `targets`
+        and `filenames` already exist and have first dimension larger than
+        `sum(images_per_class)`.
+    which_set : str
+        Which set of images is being processed. One of 'train', 'valid',
+        'test'.  Used for extracting the appropriate images from the patch
+        archive.
+    image_archive : str or file-like object
+        The filename or file-handle for the TAR archive containing images.
+    patch_archive : str or file-like object
+        Filename or file handle for the TAR archive of patch images.
+    groundtruth : iterable
+        Iterable container containing scalar 0-based class index for each
+        image, sorted by filename.
+    offset : int
+        The offset in the HDF5 datasets at which to start writing.
+
+    """
+    producer = partial(other_set_producer, image_archive=image_archive,
+                       patch_archive=patch_archive,
+                       groundtruth=groundtruth, which_set=which_set)
+    consumer = partial(image_consumer, hdf5_file=hdf5_file,
+                       num_expected=len(groundtruth), offset=offset)
+    producer_consumer(producer, consumer)
+
+
+def other_set_producer(socket, which_set, image_archive, patch_archive,
+                       groundtruth):
+    """Push image files read from the valid/test set TAR to a socket.
+
+    Parameters
+    ----------
+    socket : :class:`zmq.Socket`
+        PUSH socket on which to send images.
+    which_set : str
+        Which set of images is being processed. One of 'train', 'valid',
+        'test'.  Used for extracting the appropriate images from the patch
+        archive.
+    image_archive : str or file-like object
+        The filename or file-handle for the TAR archive containing images.
+    patch_archive : str or file-like object
+        Filename or file handle for the TAR archive of patch images.
+    groundtruth : iterable
+        Iterable container containing scalar 0-based class index for each
+        image, sorted by filename.
+
+    """
+    patch_images = extract_patch_images(patch_archive, which_set)
+    num_patched = 0
+    with tar_open(image_archive) as tar:
+        filenames = sorted(info.name for info in tar if info.isfile())
+        images = (load_from_tar_or_patch(tar, filename, patch_images)
+                  for filename in filenames)
+        pathless_filenames = (os.path.split(fn)[-1] for fn in filenames)
+        image_iterator = equizip(images, pathless_filenames, groundtruth)
+        for (image_data, patched), filename, class_index in image_iterator:
+            if patched:
+                num_patched += 1
+            socket.send_pyobj((filename, class_index), zmq.SNDMORE)
+            socket.send(image_data, copy=False)
+    if num_patched != len(patch_images):
+        raise Exception
+
+
+def load_from_tar_or_patch(tar, image_filename, patch_images):
+    """Do everything necessary to process an image inside a TAR.
+
+    Parameters
+    ----------
+    tar : `TarFile` instance
+        The tar from which to read `image_filename`.
+    image_filename : str
+        Fully-qualified path inside of `tar` from which to read an
+        image file.
+    patch_images : dict
+        A dictionary containing filenames (without path) of replacements
+        to be substituted in place of the version of the same file found
+        in `tar`.
+
+    Returns
+    -------
+    image_data : bytes
+        The JPEG bytes representing either the image from the TAR archive
+        or its replacement from the patch dictionary.
+    patched : bool
+        True if the image was retrieved from the patch dictionary. False
+        if it was retrieved from the TAR file.
+
+    """
+    patched = True
+    image_bytes = patch_images.get(os.path.basename(image_filename), None)
+    if image_bytes is None:
+        patched = False
+        try:
+            image_bytes = tar.extractfile(image_filename).read()
+            numpy.array(Image.open(io.BytesIO(image_bytes)))
+        except (IOError, OSError):
+            with gzip.GzipFile(fileobj=tar.extractfile(image_filename)) as gz:
+                image_bytes = gz.read()
+                numpy.array(Image.open(io.BytesIO(image_bytes)))
+    return image_bytes, patched
+
+
+def read_devkit(f):
+    """Read relevant information from the development kit archive.
+
+    Parameters
+    ----------
+    f : str or file-like object
+        The filename or file-handle for the gzipped TAR archive
+        containing the ILSVRC2010 development kit.
+
+    Returns
+    -------
+    synsets : ndarray, 1-dimensional, compound dtype
+        See :func:`read_metadata_mat_file` for details.
+    cost_matrix : ndarray, 2-dimensional, uint8
+        See :func:`read_metadata_mat_file` for details.
+    raw_valid_groundtruth : ndarray, 1-dimensional, int16
+        The labels for the ILSVRC2010 validation set,
+        distributed with the development kit code.
+
+    """
+    with tar_open(f) as tar:
+        # Metadata table containing class hierarchy, textual descriptions, etc.
+        meta_mat = tar.extractfile(DEVKIT_META_PATH)
+        synsets, cost_matrix = read_metadata_mat_file(meta_mat)
+
+        # Raw validation data groundtruth, ILSVRC2010 IDs. Confusingly
+        # distributed inside the development kit archive.
+        raw_valid_groundtruth = numpy.loadtxt(tar.extractfile(
+            DEVKIT_VALID_GROUNDTRUTH_PATH), dtype=numpy.int16)
+    return synsets, cost_matrix, raw_valid_groundtruth
+
+
+def read_metadata_mat_file(meta_mat):
+    """Read ILSVRC2010 metadata from the distributed MAT file.
+
+    Parameters
+    ----------
+    meta_mat : str or file-like object
+        The filename or file-handle for `meta.mat` from the
+        ILSVRC2010 development kit.
+
+    Returns
+    -------
+    synsets : ndarray, 1-dimensional, compound dtype
+        A table containing ILSVRC2010 metadata for the "synonym sets"
+        or "synsets" that comprise the classes and superclasses,
+        including the following fields:
+         * `ILSVRC2010_ID`: the integer ID used in the original
+           competition data.
+         * `WNID`: A string identifier that uniquely identifies
+           a synset in ImageNet and WordNet.
+         * `wordnet_height`: The length of the longest path to
+           a leaf node in the FULL ImageNet/WordNet hierarchy
+           (leaf nodes in the FULL ImageNet/WordNet hierarchy
+           have `wordnet_height` 0).
+         * `gloss`: A string representation of an English
+           textual description of the concept represented by
+           this synset.
+         * `num_children`: The number of children in the hierarchy
+           for this synset.
+         * `words`: A string representation, comma separated,
+           of different synoym words or phrases for the concept
+           represented by this synset.
+         * `children`: A vector of `ILSVRC2010_ID`s of children
+           of this synset, padded with -1. Note that these refer
+           to `ILSVRC2010_ID`s from the original data and *not*
+           the zero-based index in the table.
+         * `num_train_images`: The number of training images for
+           this synset.
+    cost_matrix : ndarray, 2-dimensional, uint8
+        A 1000x1000 matrix containing the precomputed pairwise
+        cost (based on distance in the hierarchy) for all
+        low-level synsets (i.e. the thousand possible output
+        classes with training data associated).
+
+    """
+    mat = loadmat(meta_mat, squeeze_me=True)
+    synsets = mat['synsets']
+    cost_matrix = mat['cost_matrix']
+    new_dtype = numpy.dtype([
+        ('ILSVRC2010_ID', numpy.int16),
+        ('WNID', ('S', max(map(len, synsets['WNID'])))),
+        ('wordnet_height', numpy.int8),
+        ('gloss', ('S', max(map(len, synsets['gloss'])))),
+        ('num_children', numpy.int8),
+        ('words', ('S', max(map(len, synsets['words'])))),
+        ('children', (numpy.int8, max(synsets['num_children']))),
+        ('num_train_images', numpy.uint16)
+    ])
+    new_synsets = numpy.empty(synsets.shape, dtype=new_dtype)
+    for attr in ['ILSVRC2010_ID', 'WNID', 'wordnet_height', 'gloss',
+                 'num_children', 'words', 'num_train_images']:
+        new_synsets[attr] = synsets[attr]
+    children = [numpy.atleast_1d(ch) for ch in synsets['children']]
+    padded_children = [
+        numpy.concatenate((c,
+                           -numpy.ones(new_dtype['children'].shape[0] - len(c),
+                                       dtype=numpy.int16)))
+        for c in children
+    ]
+    new_synsets['children'] = padded_children
+    return new_synsets, cost_matrix
+
+
+def extract_patch_images(f, which_set):
+    """Extracts a dict of the "patch images" for ILSVRC2010.
+
+    Parameters
+    ----------
+    f : str or file-like object
+        The filename or file-handle to the patch images TAR file.
+    which_set : str
+        Which set of images to extract. One of 'train', 'valid', 'test'.
+
+    Returns
+    -------
+    dict
+        A dictionary contains a mapping of filenames (without path) to a
+        bytes object containing the replacement image.
+
+    Notes
+    -----
+    Certain images in the distributed archives are blank, or display
+    an "image not available" banner. A separate TAR file of
+    "patch images" is distributed with the corrected versions of
+    these. It is this archive that this function is intended to read.
+
+    """
+    if which_set not in ('train', 'valid', 'test'):
+        raise ValueError('which_set must be one of train, valid, or test')
+    which_set = 'val' if which_set == 'valid' else which_set
+    patch_images = {}
+    with tar_open(f) as tar:
+        for info_obj in tar:
+            if not info_obj.name.endswith('.JPEG'):
+                continue
+            # Pretty sure that '/' is used for tarfile regardless of
+            # os.path.sep, but I officially don't care about Windows.
+            tokens = info_obj.name.split('/')
+            file_which_set = tokens[-2]
+            if file_which_set != which_set:
+                continue
+            filename = tokens[-1]
+            patch_images[filename] = tar.extractfile(info_obj.name).read()
+    return patch_images

--- a/fuel/converters/ilsvrc2012.py
+++ b/fuel/converters/ilsvrc2012.py
@@ -1,25 +1,22 @@
 from __future__ import division
-from collections import OrderedDict
-from functools import partial
-import gzip
-import io
-import os
 import logging
 import os.path
+import tarfile
+import tempfile
+from collections import OrderedDict
+from contextlib import contextmanager
 
 import h5py
 import numpy
-from picklable_itertools.extras import equizip
-from PIL import Image
 from scipy.io.matlab import loadmat
 from six.moves import zip, xrange
-import zmq
 
-from fuel.converters.base import check_exists, progress_bar
+from fuel import config
+from fuel.converters.base import check_exists
 from fuel.datasets import H5PYDataset
 from fuel.utils.formats import tar_open
-from fuel.utils.parallel import producer_consumer
-from fuel import config
+from .ilsvrc2010 import (process_train_set,
+                         process_other_set)
 
 log = logging.getLogger(__name__)
 
@@ -66,15 +63,16 @@ def convert_ilsvrc2012(directory, output_directory,
     n_valid = len(valid_groundtruth)
     output_path = os.path.join(output_directory, output_filename)
 
-    with h5py.File(output_path, 'w') as f:
+    with h5py.File(output_path, 'w') as f, create_temp_tar() as patch:
         log.info('Creating HDF5 datasets...')
         prepare_hdf5_file(f, n_train, n_valid, n_test)
         log.info('Processing training set...')
-        process_train_set(f, train, n_train, wnid_map, shuffle_seed)
+        process_train_set(f, train, patch, n_train, wnid_map, shuffle_seed)
         log.info('Processing validation set...')
-        process_other_set(f, 'valid', valid, valid_groundtruth, n_train)
+        process_other_set(f, 'valid', valid, patch, valid_groundtruth, n_train)
         log.info('Processing test set...')
-        process_other_set(f, 'test', test, (None,) * n_test, n_train + n_valid)
+        process_other_set(f, 'test', patch, None, (None,) * n_test,
+                          n_train + n_valid)
         log.info('Done.')
 
     return (output_path,)
@@ -162,6 +160,17 @@ def create_splits(n_train, n_valid, n_test):
     )
 
 
+@contextmanager
+def create_temp_tar():
+    try:
+        _, temp_tar = tempfile.mkstemp(suffix='.tar')
+        with tarfile.open(temp_tar, mode='w') as tar:
+            tar.addfile(tarfile.TarInfo())
+        yield temp_tar
+    finally:
+        os.remove(temp_tar)
+
+
 def prepare_hdf5_file(hdf5_file, n_train, n_valid, n_test):
     """Create datasets within a given HDF5 file.
 
@@ -187,193 +196,6 @@ def prepare_hdf5_file(hdf5_file, n_train, n_valid, n_test):
     hdf5_file.create_dataset('targets', shape=(n_labeled, 1),
                              dtype=numpy.int16)
     hdf5_file.create_dataset('filenames', shape=(n_total, 1), dtype='S32')
-
-
-def process_train_set(hdf5_file, train_archive, n_train,
-                      wnid_map, shuffle_seed=None):
-    """Process the ILSVRC2012 training set.
-
-    Parameters
-    ----------
-    hdf5_file : :class:`h5py.File` instance
-        HDF5 file handle to which to write. Assumes `features`, `targets`
-        and `filenames` already exist and have first dimension larger than
-        `n_train`.
-    train_archive :  str or file-like object
-        Filename or file handle for the TAR archive of training images.
-    n_train : int
-        The number of items in the training set.
-    wnid_map : dict
-        A dictionary mapping WordNet IDs to class indices.
-    shuffle_seed : int or sequence, optional
-        Seed for a NumPy random number generator that permutes the
-        training set on disk. If `None`, no permutation is performed
-        (this is the default).
-
-    """
-    producer = partial(train_set_producer, train_archive=train_archive,
-                       wnid_map=wnid_map)
-    consumer = partial(image_consumer, hdf5_file=hdf5_file,
-                       num_expected=n_train, shuffle_seed=shuffle_seed)
-    producer_consumer(producer, consumer)
-
-
-def _write_to_hdf5(hdf5_file, index, image_filename, image_data,
-                   class_index):
-    hdf5_file['filenames'][index] = image_filename.encode('ascii')
-    hdf5_file['encoded_images'][index] = image_data
-    if class_index is not None:
-        hdf5_file['targets'][index] = class_index
-
-
-def train_set_producer(socket, train_archive, wnid_map):
-    """Load/send images from the training set TAR file or patch images.
-
-    Parameters
-    ----------
-    socket : :class:`zmq.Socket`
-        PUSH socket on which to send loaded images.
-    train_archive :  str or file-like object
-        Filename or file handle for the TAR archive of training images.
-    wnid_map : dict
-        A dictionary that maps WordNet IDs to 0-based class indices.
-        Used to decode the filenames of the inner TAR files.
-
-    """
-    with tar_open(train_archive) as tar:
-        for inner_tar_info in tar:
-            with tar_open(tar.extractfile(inner_tar_info.name)) as inner:
-                wnid = inner_tar_info.name.split('.')[0]
-                class_index = wnid_map[wnid]
-                filenames = sorted(info.name for info in inner
-                                   if info.isfile())
-                images_gen = (load_from_tar(inner, filename)
-                              for filename in filenames)
-                stream = equizip(filenames, images_gen)
-                for image_fn, image_data in stream:
-                    socket.send_pyobj((image_fn, class_index), zmq.SNDMORE)
-                    socket.send(image_data)
-
-
-def image_consumer(socket, hdf5_file, num_expected, shuffle_seed=None,
-                   offset=0):
-    """Fill an HDF5 file with incoming images from a socket.
-
-    Parameters
-    ----------
-    socket : :class:`zmq.Socket`
-        PULL socket on which to receive images.
-    hdf5_file : :class:`h5py.File` instance
-        HDF5 file handle to which to write. Assumes `features`, `targets`
-        and `filenames` already exist and have first dimension larger than
-        `sum(images_per_class)`.
-    num_expected : int
-        The number of items we expect to be sent over the socket.
-    shuffle_seed : int or sequence, optional
-        Seed for a NumPy random number generator that permutes the
-        images on disk.
-    offset : int, optional
-        The offset in the HDF5 datasets at which to start writing
-        received examples. Defaults to 0.
-
-    """
-    with progress_bar('images', maxval=num_expected) as pb:
-        if shuffle_seed is None:
-            index_gen = iter(xrange(num_expected))
-        else:
-            rng = numpy.random.RandomState(shuffle_seed)
-            index_gen = iter(rng.permutation(num_expected))
-        for i, num in enumerate(index_gen):
-            image_filename, class_index = socket.recv_pyobj(zmq.SNDMORE)
-            image_data = numpy.fromstring(socket.recv(), dtype='uint8')
-            _write_to_hdf5(hdf5_file, num + offset, image_filename,
-                           image_data, class_index)
-            pb.update(i + 1)
-
-
-def process_other_set(hdf5_file, which_set, image_archive,
-                      groundtruth, offset):
-    """Process the validation or test set.
-
-    Parameters
-    ----------
-    hdf5_file : :class:`h5py.File` instance
-        HDF5 file handle to which to write. Assumes `features`, `targets`
-        and `filenames` already exist and have first dimension larger than
-        `sum(images_per_class)`.
-    which_set : str
-        Which set of images is being processed. One of 'train', 'valid',
-        'test'.  Used for extracting the appropriate images from the patch
-        archive.
-    image_archive : str or file-like object
-        The filename or file-handle for the TAR archive containing images.
-    groundtruth : iterable
-        Iterable container containing scalar 0-based class index for each
-        image, sorted by filename.
-    offset : int
-        The offset in the HDF5 datasets at which to start writing.
-
-    """
-    producer = partial(other_set_producer, image_archive=image_archive,
-                       groundtruth=groundtruth, which_set=which_set)
-    consumer = partial(image_consumer, hdf5_file=hdf5_file,
-                       num_expected=len(groundtruth), offset=offset)
-    producer_consumer(producer, consumer)
-
-
-def other_set_producer(socket, which_set, image_archive, groundtruth):
-    """Push image files read from the valid/test set TAR to a socket.
-
-    Parameters
-    ----------
-    socket : :class:`zmq.Socket`
-        PUSH socket on which to send images.
-    which_set : str
-        Which set of images is being processed. One of 'train', 'valid',
-        'test'.  Used for extracting the appropriate images from the patch
-        archive.
-    image_archive : str or file-like object
-        The filename or file-handle for the TAR archive containing images.
-    groundtruth : iterable
-        Iterable container containing scalar 0-based class index for each
-        image, sorted by filename.
-
-    """
-    with tar_open(image_archive) as tar:
-        filenames = sorted(info.name for info in tar if info.isfile())
-        images = (load_from_tar(tar, filename)
-                  for filename in filenames)
-        stream = equizip(filenames, images, groundtruth)
-        for image_fn, image_data, class_index in stream:
-            socket.send_pyobj((image_fn, class_index), zmq.SNDMORE)
-            socket.send(image_data, copy=False)
-
-
-def load_from_tar(tar, image_filename):
-    """Do everything necessary to process an image inside a TAR.
-
-    Parameters
-    ----------
-    tar : `TarFile` instance
-        The tar from which to read `image_filename`.
-    image_filename : str
-        Fully-qualified path inside of `tar` from which to read an
-        image file.
-
-    Returns
-    -------
-    image_data : bytes
-        The JPEG bytes representing the image from the TAR archive.
-
-    """
-    try:
-        image_bytes = tar.extractfile(image_filename).read()
-        numpy.array(Image.open(io.BytesIO(image_bytes)))
-    except (IOError, OSError):
-        with gzip.GzipFile(fileobj=tar.extractfile(image_filename)) as gz:
-            image_bytes = gz.read()
-            numpy.array(Image.open(io.BytesIO(image_bytes)))
-    return image_bytes
 
 
 def read_devkit(f):

--- a/fuel/converters/ilsvrc2012.py
+++ b/fuel/converters/ilsvrc2012.py
@@ -71,7 +71,7 @@ def convert_ilsvrc2012(directory, output_directory,
         log.info('Processing validation set...')
         process_other_set(f, 'valid', valid, patch, valid_groundtruth, n_train)
         log.info('Processing test set...')
-        process_other_set(f, 'test', patch, None, (None,) * n_test,
+        process_other_set(f, 'test', test, patch, (None,) * n_test,
                           n_train + n_valid)
         log.info('Done.')
 

--- a/fuel/converters/ilsvrc2012.py
+++ b/fuel/converters/ilsvrc2012.py
@@ -23,29 +23,25 @@ from fuel import config
 
 log = logging.getLogger(__name__)
 
-DEVKIT_ARCHIVE = 'ILSVRC2010_devkit-1.0.tar.gz'
-DEVKIT_META_PATH = 'devkit-1.0/data/meta.mat'
-DEVKIT_VALID_GROUNDTRUTH_PATH = ('devkit-1.0/data/'
-                                 'ILSVRC2010_validation_ground_truth.txt')
-PATCH_IMAGES_TAR = 'patch_images.tar'
-TEST_GROUNDTRUTH = 'ILSVRC2010_test_ground_truth.txt'
-TRAIN_IMAGES_TAR = 'ILSVRC2010_images_train.tar'
-VALID_IMAGES_TAR = 'ILSVRC2010_images_val.tar'
-TEST_IMAGES_TAR = 'ILSVRC2010_images_test.tar'
-IMAGE_TARS = (TRAIN_IMAGES_TAR, VALID_IMAGES_TAR, TEST_IMAGES_TAR,
-              PATCH_IMAGES_TAR)
-PUBLIC_FILES = TEST_GROUNDTRUTH, DEVKIT_ARCHIVE
-ALL_FILES = PUBLIC_FILES + IMAGE_TARS
+DEVKIT_ARCHIVE = 'ILSVRC2012_devkit_t12.tar.gz'
+DEVKIT_META_PATH = 'ILSVRC2012_devkit_t12/data/meta.mat'
+DEVKIT_VALID_GROUNDTRUTH_PATH = ('ILSVRC2012_devkit_t12/data/'
+                                 'ILSVRC2012_validation_ground_truth.txt')
+TRAIN_IMAGES_TAR = 'ILSVRC2012_img_train.tar'
+VALID_IMAGES_TAR = 'ILSVRC2012_img_val.tar'
+TEST_IMAGES_TAR = 'ILSVRC2012_img_test.tar'
+IMAGE_TARS = (TRAIN_IMAGES_TAR, VALID_IMAGES_TAR, TEST_IMAGES_TAR)
+ALL_FILES = (DEVKIT_ARCHIVE, ) + IMAGE_TARS
 
 
 @check_exists(required_files=ALL_FILES)
-def convert_ilsvrc2010(directory, output_directory,
-                       output_filename='ilsvrc2010.hdf5',
+def convert_ilsvrc2012(directory, output_directory,
+                       output_filename='ilsvrc2012.hdf5',
                        shuffle_seed=config.default_seed):
-    """Converter for data from the ILSVRC 2010 competition.
+    """Converter for data from the ILSVRC 2012 competition.
 
     Source files for this dataset can be obtained by registering at
-    [ILSVRC2010WEB].
+    [ILSVRC2012WEB].
 
     Parameters
     ----------
@@ -54,66 +50,59 @@ def convert_ilsvrc2010(directory, output_directory,
     output_directory : str
         Path to which to save the HDF5 file.
     output_filename : str, optional
-        The output filename for the HDF5 file. Default: 'ilsvrc2010.hdf5'.
+        The output filename for the HDF5 file. Default: 'ilsvrc2012.hdf5'.
     shuffle_seed : int or sequence, optional
         Seed for a random number generator used to shuffle the order
         of the training set on disk, so that sequential reads will not
         be ordered by class.
 
-    .. [ILSVRC2010WEB] http://image-net.org/challenges/LSVRC/2010/index
+    .. [ILSVRC2012WEB] http://image-net.org/challenges/LSVRC/2012/index
 
     """
     devkit_path = os.path.join(directory, DEVKIT_ARCHIVE)
-    test_groundtruth_path = os.path.join(directory, TEST_GROUNDTRUTH)
-    train, valid, test, patch = [os.path.join(directory, fn)
-                                 for fn in IMAGE_TARS]
-    n_train, valid_groundtruth, test_groundtruth, wnid_map = \
-        prepare_metadata(devkit_path, test_groundtruth_path)
-    n_valid, n_test = len(valid_groundtruth), len(test_groundtruth)
+    train, valid, test = [os.path.join(directory, fn) for fn in IMAGE_TARS]
+    n_train, valid_groundtruth, n_test, wnid_map = prepare_metadata(devkit_path)
+    n_valid = len(valid_groundtruth)
     output_path = os.path.join(output_directory, output_filename)
 
     with h5py.File(output_path, 'w') as f:
         log.info('Creating HDF5 datasets...')
         prepare_hdf5_file(f, n_train, n_valid, n_test)
         log.info('Processing training set...')
-        process_train_set(f, train, patch, n_train, wnid_map, shuffle_seed)
+        process_train_set(f, train, n_train, wnid_map, shuffle_seed)
         log.info('Processing validation set...')
-        process_other_set(f, 'valid', valid, patch, valid_groundtruth, n_train)
+        process_other_set(f, 'valid', valid, valid_groundtruth, n_train)
         log.info('Processing test set...')
-        process_other_set(f, 'test', test, patch, test_groundtruth,
-                          n_train + n_valid)
+        process_other_set(f, 'test', test, (None, ) * n_test, n_train + n_valid)
         log.info('Done.')
 
     return (output_path,)
 
 
 def fill_subparser(subparser):
-    """Sets up a subparser to convert the ILSVRC2010 dataset files.
+    """Sets up a subparser to convert the ILSVRC2012 dataset files.
 
     Parameters
     ----------
     subparser : :class:`argparse.ArgumentParser`
-        Subparser handling the `ilsvrc2010` command.
+        Subparser handling the `ilsvrc2012` command.
 
     """
     subparser.add_argument(
         "--shuffle-seed", help="Seed to use for randomizing order of the "
                                "training set on disk.",
         default=config.default_seed, type=int, required=False)
-    return convert_ilsvrc2010
+    return convert_ilsvrc2012
 
 
-def prepare_metadata(devkit_archive, test_groundtruth_path):
+def prepare_metadata(devkit_archive):
     """Extract dataset metadata required for HDF5 file setup.
 
     Parameters
     ----------
     devkit_archive : str or file-like object
         The filename or file-handle for the gzipped TAR archive
-        containing the ILSVRC2010 development kit.
-    test_groundtruth_path : str or file-like object
-        The filename or file-handle for the text file containing
-        the ILSVRC2010 test set ground truth.
+        containing the ILSVRC2012 development kit.
 
     Returns
     -------
@@ -122,45 +111,40 @@ def prepare_metadata(devkit_archive, test_groundtruth_path):
     valid_groundtruth : ndarray, 1-dimensional
         An ndarray containing the validation set groundtruth in terms of
         0-based class indices.
-    test_groundtruth : ndarray, 1-dimensional
-        An ndarray containing the test groundtruth in terms of 0-based
-        class indices.
+    n_test : int
+        The number of examples in the test set
     wnid_map : dict
         A dictionary that maps WordNet IDs to 0-based class indices.
 
     """
     # Read what's necessary from the development kit.
-    synsets, cost_matrix, raw_valid_groundtruth = read_devkit(devkit_archive)
+    synsets, raw_valid_groundtruth = read_devkit(devkit_archive)
 
     # Mapping to take WordNet IDs to our internal 0-999 encoding.
     wnid_map = dict(zip((s.decode('utf8') for s in synsets['WNID']),
                         xrange(1000)))
 
-    # Map the 'ILSVRC2010 ID' to our zero-based ID.
-    ilsvrc_id_to_zero_based = dict(zip(synsets['ILSVRC2010_ID'],
+    # Map the 'ILSVRC2012 ID' to our zero-based ID.
+    ilsvrc_id_to_zero_based = dict(zip(synsets['ILSVRC2012_ID'],
                                    xrange(len(synsets))))
 
     # Map the validation set groundtruth to 0-999 labels.
     valid_groundtruth = [ilsvrc_id_to_zero_based[id_]
                          for id_ in raw_valid_groundtruth]
 
-    # Raw test data groundtruth, ILSVRC2010 IDs.
-    raw_test_groundtruth = numpy.loadtxt(test_groundtruth_path,
-                                         dtype=numpy.int16)
-
-    # Map the test set groundtruth to 0-999 labels.
-    test_groundtruth = [ilsvrc_id_to_zero_based[id_]
-                        for id_ in raw_test_groundtruth]
+    # Get number of test examples from the test archive
+    with tar_open(TEST_IMAGES_TAR) as f:
+        n_test = sum(1 for _ in f)
 
     # Ascertain the number of filenames to prepare appropriate sized
     # arrays.
     n_train = int(synsets['num_train_images'].sum())
     log.info('Training set: {} images'.format(n_train))
     log.info('Validation set: {} images'.format(len(valid_groundtruth)))
-    log.info('Test set: {} images'.format(len(test_groundtruth)))
-    n_total = n_train + len(valid_groundtruth) + len(test_groundtruth)
-    log.info('Total (train/valid/test): {} images'.format(n_total))
-    return n_train, valid_groundtruth, test_groundtruth, wnid_map
+    log.info('Test set: {} images'.format(n_test))
+    n_total = n_train + len(valid_groundtruth) + n_test
+    log.info('Total (train/valid): {} images'.format(n_total))
+    return n_train, valid_groundtruth, n_test, wnid_map
 
 
 def create_splits(n_train, n_valid, n_test):
@@ -192,18 +176,19 @@ def prepare_hdf5_file(hdf5_file, n_train, n_valid, n_test):
 
     """
     n_total = n_train + n_valid + n_test
+    n_labeled = n_train + n_valid
     splits = create_splits(n_train, n_valid, n_test)
     hdf5_file.attrs['split'] = H5PYDataset.create_split_array(splits)
     vlen_dtype = h5py.special_dtype(vlen=numpy.dtype('uint8'))
     hdf5_file.create_dataset('encoded_images', shape=(n_total,),
                              dtype=vlen_dtype)
-    hdf5_file.create_dataset('targets', shape=(n_total, 1), dtype=numpy.int16)
+    hdf5_file.create_dataset('targets', shape=(n_labeled, 1), dtype=numpy.int16)
     hdf5_file.create_dataset('filenames', shape=(n_total, 1), dtype='S32')
 
 
-def process_train_set(hdf5_file, train_archive, patch_archive, n_train,
+def process_train_set(hdf5_file, train_archive, n_train,
                       wnid_map, shuffle_seed=None):
-    """Process the ILSVRC2010 training set.
+    """Process the ILSVRC2012 training set.
 
     Parameters
     ----------
@@ -213,8 +198,6 @@ def process_train_set(hdf5_file, train_archive, patch_archive, n_train,
         `n_train`.
     train_archive :  str or file-like object
         Filename or file handle for the TAR archive of training images.
-    patch_archive :  str or file-like object
-        Filename or file handle for the TAR archive of patch images.
     n_train : int
         The number of items in the training set.
     wnid_map : dict
@@ -226,7 +209,7 @@ def process_train_set(hdf5_file, train_archive, patch_archive, n_train,
 
     """
     producer = partial(train_set_producer, train_archive=train_archive,
-                       patch_archive=patch_archive, wnid_map=wnid_map)
+                       wnid_map=wnid_map)
     consumer = partial(image_consumer, hdf5_file=hdf5_file,
                        num_expected=n_train, shuffle_seed=shuffle_seed)
     producer_consumer(producer, consumer)
@@ -236,10 +219,11 @@ def _write_to_hdf5(hdf5_file, index, image_filename, image_data,
                    class_index):
     hdf5_file['filenames'][index] = image_filename.encode('ascii')
     hdf5_file['encoded_images'][index] = image_data
-    hdf5_file['targets'][index] = class_index
+    if class_index is not None:
+        hdf5_file['targets'][index] = class_index
 
 
-def train_set_producer(socket, train_archive, patch_archive, wnid_map):
+def train_set_producer(socket, train_archive, wnid_map):
     """Load/send images from the training set TAR file or patch images.
 
     Parameters
@@ -248,15 +232,11 @@ def train_set_producer(socket, train_archive, patch_archive, wnid_map):
         PUSH socket on which to send loaded images.
     train_archive :  str or file-like object
         Filename or file handle for the TAR archive of training images.
-    patch_archive :  str or file-like object
-        Filename or file handle for the TAR archive of patch images.
     wnid_map : dict
         A dictionary that maps WordNet IDs to 0-based class indices.
         Used to decode the filenames of the inner TAR files.
 
     """
-    patch_images = extract_patch_images(patch_archive, 'train')
-    num_patched = 0
     with tar_open(train_archive) as tar:
         for inner_tar_info in tar:
             with tar_open(tar.extractfile(inner_tar_info.name)) as inner:
@@ -264,19 +244,12 @@ def train_set_producer(socket, train_archive, patch_archive, wnid_map):
                 class_index = wnid_map[wnid]
                 filenames = sorted(info.name for info in inner
                                    if info.isfile())
-                images_gen = (load_from_tar_or_patch(inner, filename,
-                                                     patch_images)
+                images_gen = (load_from_tar(inner, filename)
                               for filename in filenames)
-                pathless_filenames = (os.path.split(fn)[-1]
-                                      for fn in filenames)
-                stream = equizip(pathless_filenames, images_gen)
-                for image_fn, (image_data, patched) in stream:
-                    if patched:
-                        num_patched += 1
+                stream = equizip(filenames, images_gen)
+                for image_fn, image_data in stream:
                     socket.send_pyobj((image_fn, class_index), zmq.SNDMORE)
                     socket.send(image_data)
-    if num_patched != len(patch_images):
-        raise ValueError('not all patch images were used')
 
 
 def image_consumer(socket, hdf5_file, num_expected, shuffle_seed=None,
@@ -315,7 +288,7 @@ def image_consumer(socket, hdf5_file, num_expected, shuffle_seed=None,
             pb.update(i + 1)
 
 
-def process_other_set(hdf5_file, which_set, image_archive, patch_archive,
+def process_other_set(hdf5_file, which_set, image_archive,
                       groundtruth, offset):
     """Process the validation or test set.
 
@@ -331,8 +304,6 @@ def process_other_set(hdf5_file, which_set, image_archive, patch_archive,
         archive.
     image_archive : str or file-like object
         The filename or file-handle for the TAR archive containing images.
-    patch_archive : str or file-like object
-        Filename or file handle for the TAR archive of patch images.
     groundtruth : iterable
         Iterable container containing scalar 0-based class index for each
         image, sorted by filename.
@@ -341,15 +312,13 @@ def process_other_set(hdf5_file, which_set, image_archive, patch_archive,
 
     """
     producer = partial(other_set_producer, image_archive=image_archive,
-                       patch_archive=patch_archive,
                        groundtruth=groundtruth, which_set=which_set)
     consumer = partial(image_consumer, hdf5_file=hdf5_file,
                        num_expected=len(groundtruth), offset=offset)
     producer_consumer(producer, consumer)
 
 
-def other_set_producer(socket, which_set, image_archive, patch_archive,
-                       groundtruth):
+def other_set_producer(socket, which_set, image_archive, groundtruth):
     """Push image files read from the valid/test set TAR to a socket.
 
     Parameters
@@ -362,31 +331,22 @@ def other_set_producer(socket, which_set, image_archive, patch_archive,
         archive.
     image_archive : str or file-like object
         The filename or file-handle for the TAR archive containing images.
-    patch_archive : str or file-like object
-        Filename or file handle for the TAR archive of patch images.
     groundtruth : iterable
         Iterable container containing scalar 0-based class index for each
         image, sorted by filename.
 
     """
-    patch_images = extract_patch_images(patch_archive, which_set)
-    num_patched = 0
     with tar_open(image_archive) as tar:
         filenames = sorted(info.name for info in tar if info.isfile())
-        images = (load_from_tar_or_patch(tar, filename, patch_images)
+        images = (load_from_tar(tar, filename)
                   for filename in filenames)
-        pathless_filenames = (os.path.split(fn)[-1] for fn in filenames)
-        image_iterator = equizip(images, pathless_filenames, groundtruth)
-        for (image_data, patched), filename, class_index in image_iterator:
-            if patched:
-                num_patched += 1
-            socket.send_pyobj((filename, class_index), zmq.SNDMORE)
+        stream = equizip(filenames, images, groundtruth)
+        for image_fn, image_data, class_index in stream:
+            socket.send_pyobj((image_fn, class_index), zmq.SNDMORE)
             socket.send(image_data, copy=False)
-    if num_patched != len(patch_images):
-        raise Exception
 
 
-def load_from_tar_or_patch(tar, image_filename, patch_images):
+def load_from_tar(tar, image_filename):
     """Do everything necessary to process an image inside a TAR.
 
     Parameters
@@ -396,33 +356,21 @@ def load_from_tar_or_patch(tar, image_filename, patch_images):
     image_filename : str
         Fully-qualified path inside of `tar` from which to read an
         image file.
-    patch_images : dict
-        A dictionary containing filenames (without path) of replacements
-        to be substituted in place of the version of the same file found
-        in `tar`.
 
     Returns
     -------
     image_data : bytes
-        The JPEG bytes representing either the image from the TAR archive
-        or its replacement from the patch dictionary.
-    patched : bool
-        True if the image was retrieved from the patch dictionary. False
-        if it was retrieved from the TAR file.
+        The JPEG bytes representing the image from the TAR archive.
 
     """
-    patched = True
-    image_bytes = patch_images.get(os.path.basename(image_filename), None)
-    if image_bytes is None:
-        patched = False
-        try:
-            image_bytes = tar.extractfile(image_filename).read()
+    try:
+        image_bytes = tar.extractfile(image_filename).read()
+        numpy.array(Image.open(io.BytesIO(image_bytes)))
+    except (IOError, OSError):
+        with gzip.GzipFile(fileobj=tar.extractfile(image_filename)) as gz:
+            image_bytes = gz.read()
             numpy.array(Image.open(io.BytesIO(image_bytes)))
-        except (IOError, OSError):
-            with gzip.GzipFile(fileobj=tar.extractfile(image_filename)) as gz:
-                image_bytes = gz.read()
-                numpy.array(Image.open(io.BytesIO(image_bytes)))
-    return image_bytes, patched
+    return image_bytes
 
 
 def read_devkit(f):
@@ -432,47 +380,45 @@ def read_devkit(f):
     ----------
     f : str or file-like object
         The filename or file-handle for the gzipped TAR archive
-        containing the ILSVRC2010 development kit.
+        containing the ILSVRC2012 development kit.
 
     Returns
     -------
     synsets : ndarray, 1-dimensional, compound dtype
         See :func:`read_metadata_mat_file` for details.
-    cost_matrix : ndarray, 2-dimensional, uint8
-        See :func:`read_metadata_mat_file` for details.
     raw_valid_groundtruth : ndarray, 1-dimensional, int16
-        The labels for the ILSVRC2010 validation set,
+        The labels for the ILSVRC2012 validation set,
         distributed with the development kit code.
 
     """
     with tar_open(f) as tar:
         # Metadata table containing class hierarchy, textual descriptions, etc.
         meta_mat = tar.extractfile(DEVKIT_META_PATH)
-        synsets, cost_matrix = read_metadata_mat_file(meta_mat)
+        synsets = read_metadata_mat_file(meta_mat)
 
-        # Raw validation data groundtruth, ILSVRC2010 IDs. Confusingly
+        # Raw validation data groundtruth, ILSVRC2012 IDs. Confusingly
         # distributed inside the development kit archive.
         raw_valid_groundtruth = numpy.loadtxt(tar.extractfile(
             DEVKIT_VALID_GROUNDTRUTH_PATH), dtype=numpy.int16)
-    return synsets, cost_matrix, raw_valid_groundtruth
+    return synsets, raw_valid_groundtruth
 
 
 def read_metadata_mat_file(meta_mat):
-    """Read ILSVRC2010 metadata from the distributed MAT file.
+    """Read ILSVRC2012 metadata from the distributed MAT file.
 
     Parameters
     ----------
     meta_mat : str or file-like object
         The filename or file-handle for `meta.mat` from the
-        ILSVRC2010 development kit.
+        ILSVRC2012 development kit.
 
     Returns
     -------
     synsets : ndarray, 1-dimensional, compound dtype
-        A table containing ILSVRC2010 metadata for the "synonym sets"
+        A table containing ILSVRC2012 metadata for the "synonym sets"
         or "synsets" that comprise the classes and superclasses,
         including the following fields:
-         * `ILSVRC2010_ID`: the integer ID used in the original
+         * `ILSVRC2012_ID`: the integer ID used in the original
            competition data.
          * `WNID`: A string identifier that uniquely identifies
            a synset in ImageNet and WordNet.
@@ -488,24 +434,18 @@ def read_metadata_mat_file(meta_mat):
          * `words`: A string representation, comma separated,
            of different synoym words or phrases for the concept
            represented by this synset.
-         * `children`: A vector of `ILSVRC2010_ID`s of children
+         * `children`: A vector of `ILSVRC2012_ID`s of children
            of this synset, padded with -1. Note that these refer
-           to `ILSVRC2010_ID`s from the original data and *not*
+           to `ILSVRC2012_ID`s from the original data and *not*
            the zero-based index in the table.
          * `num_train_images`: The number of training images for
            this synset.
-    cost_matrix : ndarray, 2-dimensional, uint8
-        A 1000x1000 matrix containing the precomputed pairwise
-        cost (based on distance in the hierarchy) for all
-        low-level synsets (i.e. the thousand possible output
-        classes with training data associated).
 
     """
     mat = loadmat(meta_mat, squeeze_me=True)
     synsets = mat['synsets']
-    cost_matrix = mat['cost_matrix']
     new_dtype = numpy.dtype([
-        ('ILSVRC2010_ID', numpy.int16),
+        ('ILSVRC2012_ID', numpy.int16),
         ('WNID', ('S', max(map(len, synsets['WNID'])))),
         ('wordnet_height', numpy.int8),
         ('gloss', ('S', max(map(len, synsets['gloss'])))),
@@ -515,7 +455,7 @@ def read_metadata_mat_file(meta_mat):
         ('num_train_images', numpy.uint16)
     ])
     new_synsets = numpy.empty(synsets.shape, dtype=new_dtype)
-    for attr in ['ILSVRC2010_ID', 'WNID', 'wordnet_height', 'gloss',
+    for attr in ['ILSVRC2012_ID', 'WNID', 'wordnet_height', 'gloss',
                  'num_children', 'words', 'num_train_images']:
         new_synsets[attr] = synsets[attr]
     children = [numpy.atleast_1d(ch) for ch in synsets['children']]
@@ -526,47 +466,4 @@ def read_metadata_mat_file(meta_mat):
         for c in children
     ]
     new_synsets['children'] = padded_children
-    return new_synsets, cost_matrix
-
-
-def extract_patch_images(f, which_set):
-    """Extracts a dict of the "patch images" for ILSVRC2010.
-
-    Parameters
-    ----------
-    f : str or file-like object
-        The filename or file-handle to the patch images TAR file.
-    which_set : str
-        Which set of images to extract. One of 'train', 'valid', 'test'.
-
-    Returns
-    -------
-    dict
-        A dictionary contains a mapping of filenames (without path) to a
-        bytes object containing the replacement image.
-
-    Notes
-    -----
-    Certain images in the distributed archives are blank, or display
-    an "image not available" banner. A separate TAR file of
-    "patch images" is distributed with the corrected versions of
-    these. It is this archive that this function is intended to read.
-
-    """
-    if which_set not in ('train', 'valid', 'test'):
-        raise ValueError('which_set must be one of train, valid, or test')
-    which_set = 'val' if which_set == 'valid' else which_set
-    patch_images = {}
-    with tar_open(f) as tar:
-        for info_obj in tar:
-            if not info_obj.name.endswith('.JPEG'):
-                continue
-            # Pretty sure that '/' is used for tarfile regardless of
-            # os.path.sep, but I officially don't care about Windows.
-            tokens = info_obj.name.split('/')
-            file_which_set = tokens[-2]
-            if file_which_set != which_set:
-                continue
-            filename = tokens[-1]
-            patch_images[filename] = tar.extractfile(info_obj.name).read()
-    return patch_images
+    return new_synsets

--- a/fuel/converters/ilsvrc2012.py
+++ b/fuel/converters/ilsvrc2012.py
@@ -31,7 +31,7 @@ TRAIN_IMAGES_TAR = 'ILSVRC2012_img_train.tar'
 VALID_IMAGES_TAR = 'ILSVRC2012_img_val.tar'
 TEST_IMAGES_TAR = 'ILSVRC2012_img_test.tar'
 IMAGE_TARS = (TRAIN_IMAGES_TAR, VALID_IMAGES_TAR, TEST_IMAGES_TAR)
-ALL_FILES = (DEVKIT_ARCHIVE, ) + IMAGE_TARS
+ALL_FILES = (DEVKIT_ARCHIVE,) + IMAGE_TARS
 
 
 @check_exists(required_files=ALL_FILES)
@@ -61,7 +61,8 @@ def convert_ilsvrc2012(directory, output_directory,
     """
     devkit_path = os.path.join(directory, DEVKIT_ARCHIVE)
     train, valid, test = [os.path.join(directory, fn) for fn in IMAGE_TARS]
-    n_train, valid_groundtruth, n_test, wnid_map = prepare_metadata(devkit_path)
+    n_train, valid_groundtruth, n_test, wnid_map = prepare_metadata(
+        devkit_path)
     n_valid = len(valid_groundtruth)
     output_path = os.path.join(output_directory, output_filename)
 
@@ -73,7 +74,7 @@ def convert_ilsvrc2012(directory, output_directory,
         log.info('Processing validation set...')
         process_other_set(f, 'valid', valid, valid_groundtruth, n_train)
         log.info('Processing test set...')
-        process_other_set(f, 'test', test, (None, ) * n_test, n_train + n_valid)
+        process_other_set(f, 'test', test, (None,) * n_test, n_train + n_valid)
         log.info('Done.')
 
     return (output_path,)
@@ -126,7 +127,7 @@ def prepare_metadata(devkit_archive):
 
     # Map the 'ILSVRC2012 ID' to our zero-based ID.
     ilsvrc_id_to_zero_based = dict(zip(synsets['ILSVRC2012_ID'],
-                                   xrange(len(synsets))))
+                                       xrange(len(synsets))))
 
     # Map the validation set groundtruth to 0-999 labels.
     valid_groundtruth = [ilsvrc_id_to_zero_based[id_]
@@ -183,7 +184,8 @@ def prepare_hdf5_file(hdf5_file, n_train, n_valid, n_test):
     vlen_dtype = h5py.special_dtype(vlen=numpy.dtype('uint8'))
     hdf5_file.create_dataset('encoded_images', shape=(n_total,),
                              dtype=vlen_dtype)
-    hdf5_file.create_dataset('targets', shape=(n_labeled, 1), dtype=numpy.int16)
+    hdf5_file.create_dataset('targets', shape=(n_labeled, 1),
+                             dtype=numpy.int16)
     hdf5_file.create_dataset('filenames', shape=(n_total, 1), dtype='S32')
 
 

--- a/fuel/converters/ilsvrc2012.py
+++ b/fuel/converters/ilsvrc2012.py
@@ -155,7 +155,8 @@ def create_splits(n_train, n_valid, n_test):
     tuples['test'] = (n_train + n_valid, n_total)
     sources = ['encoded_images', 'targets', 'filenames']
     return OrderedDict(
-        (split, OrderedDict((source, tuples[split]) for source in sources))
+        (split, OrderedDict((source, tuples[split]) for source in sources
+                            if source != 'targets' or split != 'test'))
         for split in ('train', 'valid', 'test')
     )
 

--- a/fuel/datasets/imagenet.py
+++ b/fuel/datasets/imagenet.py
@@ -39,3 +39,40 @@ class ILSVRC2010(H5PYDataset):
         super(ILSVRC2010, self).__init__(
             file_or_path=find_in_data_path(self.filename),
             which_sets=which_sets, **kwargs)
+
+
+class ILSVRC2012(H5PYDataset):
+    u"""The ILSVRC2010 Dataset.
+
+    The ImageNet Large-Scale Visual Recognition Challenge [ILSVRC]
+    is an annual computer vision competition testing object classification
+    and detection at large-scale. This is a wrapper around the data for
+    the 2010 competition, which is (as of 2015) the only year for which
+    test data groundtruth is available.
+
+    Note that the download site for the images is not publicly
+    accessible. To downlaod the images, you may sign up for an account
+    at [SIGNUP].
+
+    .. [ILSVRC] Olga Russakovsky, Jia Deng, Hao Su, Jonathan Krause,
+       Sanjeev Satheesh, Sean Ma, Zhiheng Huang, Andrej Karpathy, Aditya
+       Khosla, Michael Bernstein, Alexander C. Berg and Li Fei-Fei.
+       *ImageNet Large Scale Visual Recognition Challenge*. IJCV, 2015.
+
+    .. [SIGNUP] http://www.image-net.org/signup
+
+    Parameters
+    ----------
+    which_sets : tuple of str
+        Which split to load. Valid values are 'train' (1.2M examples)
+        'valid' (150,000 examples), and 'test' (50,000 examples).
+
+    """
+    filename = 'ilsvrc2010.hdf5'
+    default_transformers = rgb_images_from_encoded_bytes(('encoded_images',))
+
+    def __init__(self, which_sets, **kwargs):
+        kwargs.setdefault('load_in_memory', False)
+        super(ILSVRC2010, self).__init__(
+            file_or_path=find_in_data_path(self.filename),
+            which_sets=which_sets, **kwargs)

--- a/fuel/datasets/imagenet.py
+++ b/fuel/datasets/imagenet.py
@@ -42,13 +42,12 @@ class ILSVRC2010(H5PYDataset):
 
 
 class ILSVRC2012(H5PYDataset):
-    u"""The ILSVRC2010 Dataset.
+    u"""The ILSVRC2012 Dataset.
 
     The ImageNet Large-Scale Visual Recognition Challenge [ILSVRC]
     is an annual computer vision competition testing object classification
     and detection at large-scale. This is a wrapper around the data for
-    the 2010 competition, which is (as of 2015) the only year for which
-    test data groundtruth is available.
+    the 2012 competition.
 
     Note that the download site for the images is not publicly
     accessible. To downlaod the images, you may sign up for an account
@@ -64,15 +63,15 @@ class ILSVRC2012(H5PYDataset):
     Parameters
     ----------
     which_sets : tuple of str
-        Which split to load. Valid values are 'train' (1.2M examples)
-        'valid' (150,000 examples), and 'test' (50,000 examples).
+        Which split to load. Valid values are 'train' (1,281,167 examples)
+        'valid' (50,000 examples), and 'test' (100,000 examples).
 
     """
-    filename = 'ilsvrc2010.hdf5'
+    filename = 'ilsvrc2012.hdf5'
     default_transformers = rgb_images_from_encoded_bytes(('encoded_images',))
 
     def __init__(self, which_sets, **kwargs):
         kwargs.setdefault('load_in_memory', False)
-        super(ILSVRC2010, self).__init__(
+        super(ILSVRC2012, self).__init__(
             file_or_path=find_in_data_path(self.filename),
             which_sets=which_sets, **kwargs)

--- a/fuel/downloaders/__init__.py
+++ b/fuel/downloaders/__init__.py
@@ -17,6 +17,7 @@ from fuel.downloaders import iris
 from fuel.downloaders import mnist
 from fuel.downloaders import svhn
 from fuel.downloaders import ilsvrc2010
+from fuel.downloaders import ilsvrc2012
 from fuel.downloaders import youtube_audio
 
 all_downloaders = (
@@ -30,5 +31,6 @@ all_downloaders = (
     ('mnist', mnist.fill_subparser),
     ('svhn', svhn.fill_subparser),
     ('ilsvrc2010', ilsvrc2010.fill_subparser),
+    ('ilsvrc2012', ilsvrc2012.fill_subparser),
     ('dogs_vs_cats', dogs_vs_cats.fill_subparser),
     ('youtube_audio', youtube_audio.fill_subparser))

--- a/fuel/downloaders/ilsvrc2012.py
+++ b/fuel/downloaders/ilsvrc2012.py
@@ -1,0 +1,37 @@
+from fuel.converters.ilsvrc2010 import IMAGE_TARS
+from fuel.downloaders.base import default_downloader
+
+
+def fill_subparser(subparser):
+    """Sets up a subparser to download the ILSVRC2010 dataset files.
+
+    Note that you will need to use `--url-prefix` to download the
+    non-public files (namely, the TARs of images). This is a single
+    prefix that is common to all distributed files, which you can
+    obtain by registering at the ImageNet website [DOWNLOAD].
+
+    Note that these files are quite large and you may be better off
+    simply downloading them separately and running ``fuel-convert``.
+
+    .. [DOWNLOAD] http://www.image-net.org/download-images
+
+
+    Parameters
+    ----------
+    subparser : :class:`argparse.ArgumentParser`
+        Subparser handling the `ilsvrc2010` command.
+
+    """
+    urls = [
+        ('http://www.image-net.org/challenges/LSVRC/2010/'
+         'ILSVRC2010_test_ground_truth.txt'),
+        ('http://www.image-net.org/challenges/LSVRC/2010/'
+         'download/ILSVRC2010_devkit-1.0.tar.gz'),
+    ] + ([None] * len(IMAGE_TARS))
+    filenames = [None, None] + list(IMAGE_TARS)
+    subparser.set_defaults(urls=urls, filenames=filenames)
+    subparser.add_argument('-P', '--url-prefix', type=str, default=None,
+                           help="URL prefix to prepend to the filenames of "
+                                "non-public files, in order to download them. "
+                                "Be sure to include the trailing slash.")
+    return default_downloader

--- a/fuel/downloaders/ilsvrc2012.py
+++ b/fuel/downloaders/ilsvrc2012.py
@@ -1,9 +1,9 @@
-from fuel.converters.ilsvrc2010 import IMAGE_TARS
+from fuel.converters.ilsvrc2012 import ALL_FILES
 from fuel.downloaders.base import default_downloader
 
 
 def fill_subparser(subparser):
-    """Sets up a subparser to download the ILSVRC2010 dataset files.
+    """Sets up a subparser to download the ILSVRC2012 dataset files.
 
     Note that you will need to use `--url-prefix` to download the
     non-public files (namely, the TARs of images). This is a single
@@ -19,16 +19,11 @@ def fill_subparser(subparser):
     Parameters
     ----------
     subparser : :class:`argparse.ArgumentParser`
-        Subparser handling the `ilsvrc2010` command.
+        Subparser handling the `ilsvrc2012` command.
 
     """
-    urls = [
-        ('http://www.image-net.org/challenges/LSVRC/2010/'
-         'ILSVRC2010_test_ground_truth.txt'),
-        ('http://www.image-net.org/challenges/LSVRC/2010/'
-         'download/ILSVRC2010_devkit-1.0.tar.gz'),
-    ] + ([None] * len(IMAGE_TARS))
-    filenames = [None, None] + list(IMAGE_TARS)
+    urls = ([None] * len(ALL_FILES))
+    filenames = list(ALL_FILES)
     subparser.set_defaults(urls=urls, filenames=filenames)
     subparser.add_argument('-P', '--url-prefix', type=str, default=None,
                            help="URL prefix to prepend to the filenames of "

--- a/fuel/transformers/defaults.py
+++ b/fuel/transformers/defaults.py
@@ -38,5 +38,5 @@ class ToBytes(SourcewiseTransformer):
 
 
 def rgb_images_from_encoded_bytes(which_sources):
-    return ((ToBytes, [], {'which_sources': ('encoded_images',)}),
-            (ImagesFromBytes, [], {'which_sources': ('encoded_images',)}))
+    return ((ToBytes, [], {'which_sources': which_sources}),
+            (ImagesFromBytes, [], {'which_sources': which_sources}))

--- a/tests/converters/test_convert_ilsvrc2012.py
+++ b/tests/converters/test_convert_ilsvrc2012.py
@@ -9,7 +9,8 @@ from numpy.testing import assert_equal
 from test_convert_ilsvrc2010 import (create_fake_jpeg_tar,
                                      create_fake_tar_of_tars,
                                      MockH5PYFile,
-                                     MockSocket)
+                                     MockSocket,
+                                     MOCK_CONSUMER_MESSAGES)
 # from fuel.server import recv_arrays, send_arrays
 from fuel.converters.ilsvrc2012 import (image_consumer,
                                         load_from_tar,
@@ -159,18 +160,6 @@ def test_train_set_producer():
                     assert image_msg['flags'] == 0
                     image_data = load_from_tar(tar, jpeg)
                     assert image_msg['data'] == image_data
-
-
-MOCK_CONSUMER_MESSAGES = [
-    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('foo.jpeg', 2)},
-    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([6, 6, 6])},
-    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('bar.jpeg', 3)},
-    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([1, 8, 1, 2, 0])},
-    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('baz.jpeg', 5)},
-    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([1, 9, 7, 9])},
-    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('bur.jpeg', 7)},
-    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([1, 8, 6, 7])},
-]
 
 
 def test_image_consumer():

--- a/tests/converters/test_convert_ilsvrc2012.py
+++ b/tests/converters/test_convert_ilsvrc2012.py
@@ -1,0 +1,295 @@
+import io
+import tarfile
+
+import numpy
+import six
+import zmq
+from numpy.testing import assert_equal
+
+from test_convert_ilsvrc2010 import (create_fake_jpeg_tar,
+                                     create_fake_tar_of_tars,
+                                     MockH5PYFile,
+                                     MockSocket)
+# from fuel.server import recv_arrays, send_arrays
+from fuel.converters.ilsvrc2012 import (image_consumer,
+                                        load_from_tar,
+                                        other_set_producer,
+                                        prepare_hdf5_file,
+                                        prepare_metadata,
+                                        process_train_set,
+                                        process_other_set,
+                                        read_devkit,
+                                        read_metadata_mat_file,
+                                        train_set_producer,
+                                        DEVKIT_META_PATH,
+                                        DEVKIT_ARCHIVE,
+                                        TEST_IMAGES_TAR)
+from fuel.utils import find_in_data_path
+from tests import skip_if_not_available
+
+
+def test_prepare_metadata():
+    skip_if_not_available(datasets=[DEVKIT_ARCHIVE, TEST_IMAGES_TAR])
+    devkit_path = find_in_data_path(DEVKIT_ARCHIVE)
+    n_train, v_gt, n_test, wnid_map = prepare_metadata(devkit_path)
+    assert n_train == 1281167
+    assert len(v_gt) == 50000
+    assert n_test == 100000
+    assert sorted(wnid_map.values()) == list(range(1000))
+    assert all(isinstance(k, six.string_types) and len(k) == 9
+               for k in wnid_map)
+
+
+def test_prepare_hdf5_file():
+    hdf5_file = MockH5PYFile()
+    prepare_hdf5_file(hdf5_file, 10, 5, 2)
+
+    def get_start_stop(hdf5_file, split):
+        rows = [r for r in hdf5_file.attrs['split'] if
+                (r['split'].decode('utf8') == split)]
+        return dict([(r['source'].decode('utf8'), (r['start'], r['stop']))
+                     for r in rows if r['stop'] - r['start'] > 0])
+
+    # Verify properties of the train split.
+    train_splits = get_start_stop(hdf5_file, 'train')
+    assert all(v == (0, 10) for v in train_splits.values())
+    assert set(train_splits.keys()) == set([u'encoded_images', u'targets',
+                                            u'filenames'])
+
+    # Verify properties of the valid split.
+    valid_splits = get_start_stop(hdf5_file, 'valid')
+    assert all(v == (10, 15) for v in valid_splits.values())
+    assert set(valid_splits.keys()) == set([u'encoded_images', u'targets',
+                                            u'filenames'])
+
+    # Verify properties of the test split.
+    test_splits = get_start_stop(hdf5_file, 'test')
+    assert all(v == (15, 17) for v in test_splits.values())
+    assert set(test_splits.keys()) == set([u'encoded_images', u'filenames'])
+
+    from numpy import dtype
+
+    # Verify properties of the encoded_images HDF5 dataset.
+    assert hdf5_file['encoded_images'].shape[0] == 17
+    assert len(hdf5_file['encoded_images'].shape) == 1
+    assert hdf5_file['encoded_images'].dtype.kind == 'O'
+    assert hdf5_file['encoded_images'].dtype.metadata['vlen'] == dtype('uint8')
+
+    # Verify properties of the filenames dataset.
+    assert hdf5_file['filenames'].shape[0] == 17
+    assert len(hdf5_file['filenames'].shape) == 2
+    assert hdf5_file['filenames'].dtype == dtype('S32')
+
+    # Verify properties of the targets dataset.
+    assert hdf5_file['targets'].shape[0] == 15
+    assert hdf5_file['targets'].shape[1] == 1
+    assert len(hdf5_file['targets'].shape) == 2
+    assert hdf5_file['targets'].dtype == dtype('int16')
+
+
+def test_process_train_set():
+    tar_data, names, jpeg_names = create_fake_tar_of_tars(20150925, 5,
+                                                          min_num_images=45,
+                                                          max_num_images=55)
+    all_jpegs = numpy.array(sum(jpeg_names, []))
+    numpy.random.RandomState(20150925).shuffle(all_jpegs)
+    hdf5_file = MockH5PYFile()
+    prepare_hdf5_file(hdf5_file, len(all_jpegs), 0, 0)
+    wnid_map = dict(zip((n.split('.')[0] for n in names), range(len(names))))
+
+    process_train_set(hdf5_file, io.BytesIO(tar_data),
+                      len(all_jpegs), wnid_map)
+
+    # Other tests cover that the actual images are what they should be.
+    # Just do a basic verification of the filenames and targets.
+
+    assert set(all_jpegs) == set(s.decode('ascii')
+                                 for s in hdf5_file['filenames'][:, 0])
+    assert len(hdf5_file['encoded_images'][:]) == len(all_jpegs)
+    assert len(hdf5_file['targets'][:]) == len(all_jpegs)
+
+
+def test_process_other_set():
+    images, all_filenames = create_fake_jpeg_tar(3, min_num_images=30,
+                                                 max_num_images=40,
+                                                 gzip_probability=0.0)
+    all_filenames_shuffle = numpy.array(all_filenames)
+    numpy.random.RandomState(20151202).shuffle(all_filenames_shuffle)
+    hdf5_file = MockH5PYFile()
+    OFFSET = 50
+    prepare_hdf5_file(hdf5_file, OFFSET, len(all_filenames), 0)
+    groundtruth = [i % 10 for i in range(len(all_filenames))]
+    process_other_set(hdf5_file, 'valid', io.BytesIO(images), groundtruth, OFFSET)
+
+    # Other tests cover that the actual images are what they should be.
+    # Just do a basic verification of the filenames.
+
+    assert all(hdf5_file['targets'][OFFSET:, 0] == groundtruth)
+    assert all(a.decode('ascii') == b
+               for a, b in zip(hdf5_file['filenames'][OFFSET:, 0],
+                               all_filenames))
+
+
+def test_train_set_producer():
+    tar_data, names, jpeg_names = create_fake_tar_of_tars(20150923, 5,
+                                                          min_num_images=45,
+                                                          max_num_images=55)
+    all_jpegs = numpy.array(sum(jpeg_names, []))
+    numpy.random.RandomState(20150923).shuffle(all_jpegs)
+    socket = MockSocket(zmq.PUSH)
+    wnid_map = dict(zip((n.split('.')[0] for n in names), range(len(names))))
+
+    train_set_producer(socket, io.BytesIO(tar_data), wnid_map)
+    tar_data, names, jpeg_names = create_fake_tar_of_tars(20150923, 5,
+                                                          min_num_images=45,
+                                                          max_num_images=55)
+    for tar_name in names:
+        with tarfile.open(fileobj=io.BytesIO(tar_data)) as outer_tar:
+            with tarfile.open(fileobj=outer_tar.extractfile(tar_name)) as tar:
+                for record in tar:
+                    jpeg = record.name
+                    metadata_msg = socket.sent.popleft()
+                    assert metadata_msg['type'] == 'send_pyobj'
+                    assert metadata_msg['flags'] == zmq.SNDMORE
+                    key = tar_name.split('.')[0]
+                    assert metadata_msg['obj'] == (jpeg, wnid_map[key])
+
+                    image_msg = socket.sent.popleft()
+                    assert image_msg['type'] == 'send'
+                    assert image_msg['flags'] == 0
+                    image_data = load_from_tar(tar, jpeg)
+                    assert image_msg['data'] == image_data
+
+
+MOCK_CONSUMER_MESSAGES = [
+    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('foo.jpeg', 2)},
+    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([6, 6, 6])},
+    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('bar.jpeg', 3)},
+    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([1, 8, 1, 2, 0])},
+    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('baz.jpeg', 5)},
+    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([1, 9, 7, 9])},
+    {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('bur.jpeg', 7)},
+    {'type': 'recv', 'flags': 0, 'data': numpy.cast['uint8']([1, 8, 6, 7])},
+]
+
+
+def test_image_consumer():
+    mock_messages = MOCK_CONSUMER_MESSAGES
+    hdf5_file = MockH5PYFile()
+    prepare_hdf5_file(hdf5_file, 4, 5, 8)
+    socket = MockSocket(zmq.PULL, to_recv=mock_messages)
+    image_consumer(socket, hdf5_file, 4)
+
+    assert_equal(hdf5_file['encoded_images'][0], [6, 6, 6])
+    assert_equal(hdf5_file['encoded_images'][1], [1, 8, 1, 2, 0])
+    assert_equal(hdf5_file['encoded_images'][2], [1, 9, 7, 9])
+    assert_equal(hdf5_file['encoded_images'][3], [1, 8, 6, 7])
+    assert_equal(hdf5_file['filenames'][:4], [[b'foo.jpeg'], [b'bar.jpeg'],
+                                              [b'baz.jpeg'], [b'bur.jpeg']])
+    assert_equal(hdf5_file['targets'][:4], [[2], [3], [5], [7]])
+
+
+def test_images_consumer_randomized():
+    mock_messages = MOCK_CONSUMER_MESSAGES + [
+        {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('jenny.jpeg', 1)},
+        {'type': 'recv', 'flags': 0,
+         'data': numpy.cast['uint8']([8, 6, 7, 5, 3, 0, 9])}
+    ]
+    hdf5_file = MockH5PYFile()
+    prepare_hdf5_file(hdf5_file, 4, 5, 8)
+    socket = MockSocket(zmq.PULL, to_recv=mock_messages)
+    image_consumer(socket, hdf5_file, 5, offset=4, shuffle_seed=0)
+    written_data = set(tuple(s) for s in hdf5_file['encoded_images'][4:9])
+    expected_data = set(tuple(s['data']) for s in mock_messages[1::2])
+    assert written_data == expected_data
+
+    written_targets = set(hdf5_file['targets'][4:9].flatten())
+    expected_targets = set(s['obj'][1] for s in mock_messages[::2])
+    assert written_targets == expected_targets
+
+    written_filenames = set(hdf5_file['filenames'][4:9].flatten())
+    expected_filenames = set(s['obj'][0].encode('ascii')
+                             for s in mock_messages[::2])
+    assert written_filenames == expected_filenames
+
+
+def test_other_set_producer():
+    # Create some fake data.
+    num = 21
+    image_archive, filenames = create_fake_jpeg_tar(seed=1979,
+                                                    min_num_images=num,
+                                                    max_num_images=num)
+
+    groundtruth = numpy.random.RandomState(1979).random_integers(0, 50,
+                                                                 size=num)
+    assert len(groundtruth) == 21
+    gt_lookup = dict(zip(sorted(filenames), groundtruth))
+    assert len(gt_lookup) == 21
+
+    def check(which_set):
+        # Run other_set_producer and push to a fake socket.
+        socket = MockSocket(zmq.PUSH)
+        other_set_producer(socket, which_set, io.BytesIO(image_archive),
+                           groundtruth)
+
+        # Now verify the data that socket received.
+        with tarfile.open(fileobj=io.BytesIO(image_archive)) as tar:
+            for im_fn in filenames:
+                # Verify the label and flags of the first (metadata)
+                # message.
+                label = gt_lookup[im_fn]
+                metadata_msg = socket.sent.popleft()
+                assert metadata_msg['type'] == 'send_pyobj'
+                assert metadata_msg['flags'] == zmq.SNDMORE
+                assert metadata_msg['obj'] == (im_fn, label)
+                # Verify that the second (data) message came from
+                # the right place, either a patch file or a TAR.
+                data_msg = socket.sent.popleft()
+                assert data_msg['type'] == 'send'
+                assert data_msg['flags'] == 0
+                expected = load_from_tar(tar, im_fn)
+                assert data_msg['data'] == expected
+
+    check('valid')
+    check('test')
+
+
+def test_load_from_tar():
+    # Setup fake tar files.
+    images, all_filenames = create_fake_jpeg_tar(3, min_num_images=200,
+                                                 max_num_images=200,
+                                                 gzip_probability=0.0)
+
+    with tarfile.open(fileobj=io.BytesIO(images)) as tar:
+        for fn in all_filenames:
+            image = load_from_tar(tar, fn)
+            tar_image = tar.extractfile(fn).read()
+            assert image == tar_image
+
+
+def test_read_devkit():
+    skip_if_not_available(datasets=[DEVKIT_ARCHIVE])
+    synsets, raw_valid_gt = read_devkit(
+        find_in_data_path(DEVKIT_ARCHIVE))
+    # synset sanity tests appear in test_read_metadata_mat_file
+    assert raw_valid_gt.min() == 1
+    assert raw_valid_gt.max() == 1000
+    assert raw_valid_gt.dtype.kind == 'i'
+    assert raw_valid_gt.shape == (50000,)
+
+
+def test_read_metadata_mat_file():
+    skip_if_not_available(datasets=[DEVKIT_ARCHIVE])
+    with tarfile.open(find_in_data_path(DEVKIT_ARCHIVE)) as tar:
+        meta_mat = tar.extractfile(DEVKIT_META_PATH)
+        synsets = read_metadata_mat_file(meta_mat)
+    assert (synsets['ILSVRC2012_ID'] ==
+            numpy.arange(1, len(synsets) + 1)).all()
+    assert synsets['num_train_images'][1000:].sum() == 0
+    assert (synsets['num_train_images'][:1000] > 0).all()
+    assert synsets.ndim == 1
+    assert synsets['wordnet_height'].min() == 0
+    assert synsets['wordnet_height'].max() == 19
+    assert synsets['WNID'].dtype == numpy.dtype('S9')
+    assert (synsets['num_children'][:1000] == 0).all()
+    assert (synsets['children'][:1000] == -1).all()

--- a/tests/converters/test_convert_ilsvrc2012.py
+++ b/tests/converters/test_convert_ilsvrc2012.py
@@ -120,7 +120,8 @@ def test_process_other_set():
     OFFSET = 50
     prepare_hdf5_file(hdf5_file, OFFSET, len(all_filenames), 0)
     groundtruth = [i % 10 for i in range(len(all_filenames))]
-    process_other_set(hdf5_file, 'valid', io.BytesIO(images), groundtruth, OFFSET)
+    process_other_set(hdf5_file, 'valid', io.BytesIO(images),
+                      groundtruth, OFFSET)
 
     # Other tests cover that the actual images are what they should be.
     # Just do a basic verification of the filenames.
@@ -258,8 +259,7 @@ def test_load_from_tar():
 
 def test_read_devkit():
     skip_if_not_available(datasets=[DEVKIT_ARCHIVE])
-    synsets, raw_valid_gt = read_devkit(
-        find_in_data_path(DEVKIT_ARCHIVE))
+    synsets, raw_valid_gt = read_devkit(find_in_data_path(DEVKIT_ARCHIVE))
     # synset sanity tests appear in test_read_metadata_mat_file
     assert raw_valid_gt.min() == 1
     assert raw_valid_gt.max() == 1000

--- a/tests/converters/test_convert_ilsvrc2012.py
+++ b/tests/converters/test_convert_ilsvrc2012.py
@@ -1,27 +1,14 @@
-import io
 import tarfile
 
 import numpy
 import six
-import zmq
-from numpy.testing import assert_equal
 
-from test_convert_ilsvrc2010 import (create_fake_jpeg_tar,
-                                     create_fake_tar_of_tars,
-                                     MockH5PYFile,
-                                     MockSocket,
-                                     MOCK_CONSUMER_MESSAGES)
+from .test_convert_ilsvrc2010 import MockH5PYFile
 # from fuel.server import recv_arrays, send_arrays
-from fuel.converters.ilsvrc2012 import (image_consumer,
-                                        load_from_tar,
-                                        other_set_producer,
-                                        prepare_hdf5_file,
+from fuel.converters.ilsvrc2012 import (prepare_hdf5_file,
                                         prepare_metadata,
-                                        process_train_set,
-                                        process_other_set,
                                         read_devkit,
                                         read_metadata_mat_file,
-                                        train_set_producer,
                                         DEVKIT_META_PATH,
                                         DEVKIT_ARCHIVE,
                                         TEST_IMAGES_TAR)
@@ -86,175 +73,6 @@ def test_prepare_hdf5_file():
     assert hdf5_file['targets'].shape[1] == 1
     assert len(hdf5_file['targets'].shape) == 2
     assert hdf5_file['targets'].dtype == dtype('int16')
-
-
-def test_process_train_set():
-    tar_data, names, jpeg_names = create_fake_tar_of_tars(20150925, 5,
-                                                          min_num_images=45,
-                                                          max_num_images=55)
-    all_jpegs = numpy.array(sum(jpeg_names, []))
-    numpy.random.RandomState(20150925).shuffle(all_jpegs)
-    hdf5_file = MockH5PYFile()
-    prepare_hdf5_file(hdf5_file, len(all_jpegs), 0, 0)
-    wnid_map = dict(zip((n.split('.')[0] for n in names), range(len(names))))
-
-    process_train_set(hdf5_file, io.BytesIO(tar_data),
-                      len(all_jpegs), wnid_map)
-
-    # Other tests cover that the actual images are what they should be.
-    # Just do a basic verification of the filenames and targets.
-
-    assert set(all_jpegs) == set(s.decode('ascii')
-                                 for s in hdf5_file['filenames'][:, 0])
-    assert len(hdf5_file['encoded_images'][:]) == len(all_jpegs)
-    assert len(hdf5_file['targets'][:]) == len(all_jpegs)
-
-
-def test_process_other_set():
-    images, all_filenames = create_fake_jpeg_tar(3, min_num_images=30,
-                                                 max_num_images=40,
-                                                 gzip_probability=0.0)
-    all_filenames_shuffle = numpy.array(all_filenames)
-    numpy.random.RandomState(20151202).shuffle(all_filenames_shuffle)
-    hdf5_file = MockH5PYFile()
-    OFFSET = 50
-    prepare_hdf5_file(hdf5_file, OFFSET, len(all_filenames), 0)
-    groundtruth = [i % 10 for i in range(len(all_filenames))]
-    process_other_set(hdf5_file, 'valid', io.BytesIO(images),
-                      groundtruth, OFFSET)
-
-    # Other tests cover that the actual images are what they should be.
-    # Just do a basic verification of the filenames.
-
-    assert all(hdf5_file['targets'][OFFSET:, 0] == groundtruth)
-    assert all(a.decode('ascii') == b
-               for a, b in zip(hdf5_file['filenames'][OFFSET:, 0],
-                               all_filenames))
-
-
-def test_train_set_producer():
-    tar_data, names, jpeg_names = create_fake_tar_of_tars(20150923, 5,
-                                                          min_num_images=45,
-                                                          max_num_images=55)
-    all_jpegs = numpy.array(sum(jpeg_names, []))
-    numpy.random.RandomState(20150923).shuffle(all_jpegs)
-    socket = MockSocket(zmq.PUSH)
-    wnid_map = dict(zip((n.split('.')[0] for n in names), range(len(names))))
-
-    train_set_producer(socket, io.BytesIO(tar_data), wnid_map)
-    tar_data, names, jpeg_names = create_fake_tar_of_tars(20150923, 5,
-                                                          min_num_images=45,
-                                                          max_num_images=55)
-    for tar_name in names:
-        with tarfile.open(fileobj=io.BytesIO(tar_data)) as outer_tar:
-            with tarfile.open(fileobj=outer_tar.extractfile(tar_name)) as tar:
-                for record in tar:
-                    jpeg = record.name
-                    metadata_msg = socket.sent.popleft()
-                    assert metadata_msg['type'] == 'send_pyobj'
-                    assert metadata_msg['flags'] == zmq.SNDMORE
-                    key = tar_name.split('.')[0]
-                    assert metadata_msg['obj'] == (jpeg, wnid_map[key])
-
-                    image_msg = socket.sent.popleft()
-                    assert image_msg['type'] == 'send'
-                    assert image_msg['flags'] == 0
-                    image_data = load_from_tar(tar, jpeg)
-                    assert image_msg['data'] == image_data
-
-
-def test_image_consumer():
-    mock_messages = MOCK_CONSUMER_MESSAGES
-    hdf5_file = MockH5PYFile()
-    prepare_hdf5_file(hdf5_file, 4, 5, 8)
-    socket = MockSocket(zmq.PULL, to_recv=mock_messages)
-    image_consumer(socket, hdf5_file, 4)
-
-    assert_equal(hdf5_file['encoded_images'][0], [6, 6, 6])
-    assert_equal(hdf5_file['encoded_images'][1], [1, 8, 1, 2, 0])
-    assert_equal(hdf5_file['encoded_images'][2], [1, 9, 7, 9])
-    assert_equal(hdf5_file['encoded_images'][3], [1, 8, 6, 7])
-    assert_equal(hdf5_file['filenames'][:4], [[b'foo.jpeg'], [b'bar.jpeg'],
-                                              [b'baz.jpeg'], [b'bur.jpeg']])
-    assert_equal(hdf5_file['targets'][:4], [[2], [3], [5], [7]])
-
-
-def test_images_consumer_randomized():
-    mock_messages = MOCK_CONSUMER_MESSAGES + [
-        {'type': 'recv_pyobj', 'flags': zmq.SNDMORE, 'obj': ('jenny.jpeg', 1)},
-        {'type': 'recv', 'flags': 0,
-         'data': numpy.cast['uint8']([8, 6, 7, 5, 3, 0, 9])}
-    ]
-    hdf5_file = MockH5PYFile()
-    prepare_hdf5_file(hdf5_file, 4, 5, 8)
-    socket = MockSocket(zmq.PULL, to_recv=mock_messages)
-    image_consumer(socket, hdf5_file, 5, offset=4, shuffle_seed=0)
-    written_data = set(tuple(s) for s in hdf5_file['encoded_images'][4:9])
-    expected_data = set(tuple(s['data']) for s in mock_messages[1::2])
-    assert written_data == expected_data
-
-    written_targets = set(hdf5_file['targets'][4:9].flatten())
-    expected_targets = set(s['obj'][1] for s in mock_messages[::2])
-    assert written_targets == expected_targets
-
-    written_filenames = set(hdf5_file['filenames'][4:9].flatten())
-    expected_filenames = set(s['obj'][0].encode('ascii')
-                             for s in mock_messages[::2])
-    assert written_filenames == expected_filenames
-
-
-def test_other_set_producer():
-    # Create some fake data.
-    num = 21
-    image_archive, filenames = create_fake_jpeg_tar(seed=1979,
-                                                    min_num_images=num,
-                                                    max_num_images=num)
-
-    groundtruth = numpy.random.RandomState(1979).random_integers(0, 50,
-                                                                 size=num)
-    assert len(groundtruth) == 21
-    gt_lookup = dict(zip(sorted(filenames), groundtruth))
-    assert len(gt_lookup) == 21
-
-    def check(which_set):
-        # Run other_set_producer and push to a fake socket.
-        socket = MockSocket(zmq.PUSH)
-        other_set_producer(socket, which_set, io.BytesIO(image_archive),
-                           groundtruth)
-
-        # Now verify the data that socket received.
-        with tarfile.open(fileobj=io.BytesIO(image_archive)) as tar:
-            for im_fn in filenames:
-                # Verify the label and flags of the first (metadata)
-                # message.
-                label = gt_lookup[im_fn]
-                metadata_msg = socket.sent.popleft()
-                assert metadata_msg['type'] == 'send_pyobj'
-                assert metadata_msg['flags'] == zmq.SNDMORE
-                assert metadata_msg['obj'] == (im_fn, label)
-                # Verify that the second (data) message came from
-                # the right place, either a patch file or a TAR.
-                data_msg = socket.sent.popleft()
-                assert data_msg['type'] == 'send'
-                assert data_msg['flags'] == 0
-                expected = load_from_tar(tar, im_fn)
-                assert data_msg['data'] == expected
-
-    check('valid')
-    check('test')
-
-
-def test_load_from_tar():
-    # Setup fake tar files.
-    images, all_filenames = create_fake_jpeg_tar(3, min_num_images=200,
-                                                 max_num_images=200,
-                                                 gzip_probability=0.0)
-
-    with tarfile.open(fileobj=io.BytesIO(images)) as tar:
-        for fn in all_filenames:
-            image = load_from_tar(tar, fn)
-            tar_image = tar.extractfile(fn).read()
-            assert image == tar_image
 
 
 def test_read_devkit():


### PR DESCRIPTION
Implementation and documentation is based on ilsvrc2010.

##### Compare to ilsvrc2010:
- DevKit changes:
  1. No public url for download.
  2. Meta.mat no longer contains `cost_matrix`
- Data changes:
  1. Test ground truth is not provided. To get a number of test example, I use the number of files in test archive.
  2. No image patching.

Given above differences, I tried to reuse code as much as possible. But duplication wasn't avoided.