### PR TITLE
Fix cache dropping last batch

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -507,8 +507,13 @@ class Cache(Transformer):
         return super(Cache, self).get_epoch_iterator(**kwargs)
 
     def _cache(self):
-        for cache, data in zip(self.cache, next(self.child_epoch_iterator)):
-            cache.extend(data)
+        try:
+            for cache, data in zip(self.cache,
+                                   next(self.child_epoch_iterator)):
+                cache.extend(data)
+        except StopIteration:
+            if not self.cache[0]:
+                raise
 
 
 class SortMapping(object):

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -325,6 +325,14 @@ class TestCache(object):
         assert_equal(len(data[-1][0]), 100 % 7)
         assert not cached_stream.cache[0]
 
+        stream = Batch(DataStream(IterableDataset(range(3000))),
+                       ConstantScheme(3200))
+
+        cached_stream = Cache(stream, ConstantScheme(64))
+        data = list(cached_stream.get_epoch_iterator())
+        assert_equal(len(data[-1][0]), 3000 % 64)
+        assert not cached_stream.cache[0]
+
     def test_epoch_transition(self):
         cached_stream = Cache(self.stream, ConstantScheme(7, times=3))
         for _, epoch in zip(range(2), cached_stream.iterate_epochs()):


### PR DESCRIPTION
In some situations the `Cache` transformer was dropping the last batch silently. This fixes that and adds a test for it (which fails on the current `master` branch).