### PR TITLE
Changed which_sources to be tuple in dogs_vs_cats dataset

### DIFF
--- a/fuel/datasets/dogs_vs_cats.py
+++ b/fuel/datasets/dogs_vs_cats.py
@@ -22,7 +22,7 @@ class DogsVsCats(H5PYDataset):
     filename = 'dogs_vs_cats.hdf5'
 
     default_transformers = ((ScaleAndShift, [1 / 255.0, 0],
-                             {'which_sources': 'image_features'}),)
+                             {'which_sources': ('image_features',)}),)
 
     def __init__(self, which_sets, **kwargs):
         super(DogsVsCats, self).__init__(


### PR DESCRIPTION
Due to the way the SourceWiseTransformer checks whether a source is in `which_sources` (using the `in` operator), feeding `which_sources` a string rather than a tuple of strings will work in most cases. I don't think this behaviour is intended, and corrected this in the dogs_vs_cats dataset.

Consider a dataset or stream with sources `features` and `features_transformed`. If I mistakenly give my transformer `which_sources='features_transformed'`, the transformation will be performed on BOTH streams, as `'features' in 'features_transformed' == True`.

Perhaps it is useful to make a (very unpythonic) check in `SourceWiseTransformer` that raises a ValueError/TypeError if `which_sources` is not a tuple of strings. If necessary, I can create a new issue/PR for this.