### PR TITLE
recover numpy.ndarray alignment after transmisson

### DIFF
--- a/fuel/server.py
+++ b/fuel/server.py
@@ -70,7 +70,7 @@ def recv_arrays(socket):
         raise StopIteration
     arrays = []
     for header in headers:
-        data = socket.recv()
+        data = socket.recv(copy=False)
         buf = buffer_(data)
         array = numpy.frombuffer(buf, dtype=numpy.dtype(header['descr']))
         array.shape = header['shape']

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta, abstractmethod
 
 import zmq
-import numpy
 from six import add_metaclass, iteritems
 
 from fuel.iterator import DataIterator

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 import zmq
+import numpy
 from six import add_metaclass, iteritems
 
 from fuel.iterator import DataIterator
@@ -231,6 +232,8 @@ class ServerDataStream(AbstractDataStream):
         if not self.connected:
             self.connect()
         data = recv_arrays(self.socket)
+        data = [numpy.require(arr, requirements='A')
+                for arr in data]
         return tuple(data)
 
     def get_epoch_iterator(self, **kwargs):

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -232,8 +232,6 @@ class ServerDataStream(AbstractDataStream):
         if not self.connected:
             self.connect()
         data = recv_arrays(self.socket)
-        data = [numpy.require(arr, requirements='A')
-                for arr in data]
         return tuple(data)
 
     def get_epoch_iterator(self, **kwargs):


### PR DESCRIPTION
After transformation by start_server and DataServerStream, the numpy.ndarray may become unaligned. 
