### PR TITLE
Balanced sampling scheme

### DIFF
--- a/fuel/schemes.py
+++ b/fuel/schemes.py
@@ -232,16 +232,17 @@ class ShuffledScheme(BatchScheme):
 class BalancedSamplingScheme(ShuffledScheme):
     """Balanced sampling batches iterator.
 
-    Samples an equal amount of examples from each group and iterates over them
-    in shuffled batches.
+    Samples an equal amount of examples from each class (or group) and
+    iterates over them in shuffled batches.
 
     Parameters
     ----------
     targets : list of int
         The targets that represents the groups membership per class.
     samples_per_class : int, optional
-        If `True`, enforce that indices within a batch are ordered.
-        Defaults to `False`.
+        How many examples are sampled per class. If not set, the amount of
+        samples per class will be equal to the amount of examples in the
+        smallest class.
 
     Notes
     -----

--- a/fuel/schemes.py
+++ b/fuel/schemes.py
@@ -238,7 +238,7 @@ class BalancedSamplingScheme(ShuffledScheme):
     Parameters
     ----------
     targets : list of int
-        The targets that represents the groups membership per class.
+        Represents for each datapoint the class (or group).
     samples_per_class : int, optional
         How many examples are sampled per class. If not set, the amount of
         samples per class will be equal to the amount of examples in the


### PR DESCRIPTION
I created an iteration scheme that allows balanced sampling from different classes/groups/clusters. This is relevant for classification tasks where class imbalance is present (many real world problems).  If for example a dataset is very skewed the learning algorithm might ignore the small classes (especially in early stage of training). Ways to overcome this are either weighting the underrepresented classes or to sample an equal amount of examples from each class.
In this iteration scheme we focus on the latter one and enable fuel to do such an equal sampling. It both allows subsampling (i.e. downsample the over represented class) or upsampling (i.e. sample more often the under represented class with replacement) . The amount of samples per class can be specified manually. This iteration scheme is not only applicable for classification, it can be used for any kind of groups which should be represented equally in the training set (e.g. results from clustering to avoid too similar examples in semi-supervised learning).