### PR TITLE
Rename text transformers to sequence transformers in doc

### DIFF
--- a/docs/api/transformers.rst
+++ b/docs/api/transformers.rst
@@ -17,10 +17,10 @@ Transformers for image
     :undoc-members:
     :show-inheritance:
 
-Transformers for text
----------------------
+Transformers for sequences
+--------------------------
 
-.. automodule:: fuel.transformers.text
+.. automodule:: fuel.transformers.sequences
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
`transformers.text` was renamed to `transformers.sequences` long time ago.