### PR TITLE
FIX: use UTF-8 encoding when reading non-ASCII README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Installation script."""
 from os import path
 import sys
+from io import open
 from setuptools import find_packages, setup
 from distutils.extension import Extension
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.extension import Extension
 
 HERE = path.abspath(path.dirname(__file__))
 
-with open(path.join(HERE, 'README.rst')) as f:
+with open(path.join(HERE, 'README.rst'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read().strip()
 
 # Visual C++ apparently doesn't respect/know what to do with this flag.


### PR DESCRIPTION
Hi,

because of the Umlauts in README.rst, setup.py fails with
```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-efh843rm/fuel/setup.py", line 10, in <module>
        LONG_DESCRIPTION = f.read().strip()
      File "/usr/local/anaconda3/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1803: ordinal not in range(128)
```

Thanks,
wr