### PR TITLE
Auto-open out-of-memory HDF5 files.

### DIFF
--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -564,6 +564,10 @@ class H5PYDataset(Dataset):
             raise ValueError()
         data = []
         shapes = []
+        # TODO: This is not an ideal solution, really unpickling should be 
+        # restoring the state of the dataset fully, i.e. load() must be
+        # modified to account for the out-of-memory case.
+        # See https://git.io/vKkSm
         try:
             handle = self._file_handle
         except IOError:

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -564,7 +564,11 @@ class H5PYDataset(Dataset):
             raise ValueError()
         data = []
         shapes = []
-        handle = self._file_handle
+        try:
+            handle = self._file_handle
+        except IOError:
+            self._out_of_memory_open()
+            handle = self._file_handle
         for source_name, subset in zip(self.sources, self.subsets):
             # Process the data request within the context of the data source
             # subset

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -429,3 +429,12 @@ class TestH5PYDataset(object):
                      (self.vlen_features[0], self.vlen_targets[0]))
         assert_equal(next(iter_),
                      (self.vlen_features[1], self.vlen_targets[1]))
+
+    def test_dataset_get_data_without_open(self):
+        dataset = H5PYDataset(self.h5file, which_sets=('train',),
+                              load_in_memory=False)
+        try:
+            dataset.get_data(request=(slice(0, 2)))
+        except IOError:
+            assert False
+        dataset.close(None)


### PR DESCRIPTION
Fixes #343.

Realizing now that @rizar proposes a different solution. I'll look at implementing that.