### PR TITLE
Set encoding when opening README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.extension import Extension
 
 HERE = path.abspath(path.dirname(__file__))
 
-with open(path.join(HERE, 'README.rst')) as f:
+with open(path.join(HERE, 'README.rst'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read().strip()
 
 # Visual C++ apparently doesn't respect/know what to do with this flag.


### PR DESCRIPTION
This is a problem when LC_ALL=C for example.