### PR TITLE
Rename: one feature and three bug fixes

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -893,6 +893,11 @@ class Rename(AgnosticTransformer):
                            "the same new source name")
         sources = list(data_stream.sources)
         for old, new in iteritems(names):
+            if new in sources and new not in names:
+                message = ("Renaming source '{}' to '{}' "
+                           "would create two sources named '{}'"
+                           .format(old, new, new))
+                raise KeyError(message)
             if old not in sources:
                 message = ("Renaming source '{}' to '{}': "
                            "stream does not provide a source '{}'"

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -887,8 +887,14 @@ class Rename(AgnosticTransformer):
         if on_non_existent not in ('raise', 'ignore', 'warn'):
             raise ValueError("on_non_existent must be one of 'raise', "
                              "'ignore', 'warn'")
-        if len(set(names.values())) != len(names):
-            # Mapping has to be 1-to-1 for behaviour to be deterministic.
+        # We allow duplicate values in the full dictionary, but those
+        # that correspond to keys that are real sources in the data stream
+        # must be unique. This lets you use one piece of code including
+        # a Rename transformer to map disparately named sources in
+        # different datasets to a common name.
+        usable_names = {k: v for k, v in iteritems(names)
+                        if k in data_stream.sources}
+        if len(set(usable_names.values())) != len(usable_names):
             raise KeyError("multiple old source names cannot map to "
                            "the same new source name")
         sources = list(data_stream.sources)

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -887,6 +887,10 @@ class Rename(AgnosticTransformer):
         if on_non_existent not in ('raise', 'ignore', 'warn'):
             raise ValueError("on_non_existent must be one of 'raise', "
                              "'ignore', 'warn'")
+        if len(set(names.values())) != len(names):
+            # Mapping has to be 1-to-1 for behaviour to be deterministic.
+            raise KeyError("multiple old source names cannot map to "
+                           "the same new source name")
         sources = list(data_stream.sources)
         for old, new in iteritems(names):
             if old not in sources:

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -892,13 +892,14 @@ class Rename(AgnosticTransformer):
             raise KeyError("multiple old source names cannot map to "
                            "the same new source name")
         sources = list(data_stream.sources)
+        sources_lookup = {n: i for i, n in enumerate(sources)}
         for old, new in iteritems(names):
-            if new in sources and new not in names:
+            if new in sources_lookup and new not in names:
                 message = ("Renaming source '{}' to '{}' "
                            "would create two sources named '{}'"
                            .format(old, new, new))
                 raise KeyError(message)
-            if old not in sources:
+            if old not in sources_lookup:
                 message = ("Renaming source '{}' to '{}': "
                            "stream does not provide a source '{}'"
                            .format(old, new, old))
@@ -909,7 +910,7 @@ class Rename(AgnosticTransformer):
                                  'ignore': logging.DEBUG}
                     log.log(log_level[on_non_existent], message)
             else:
-                sources[sources.index(old)] = new
+                sources[sources_lookup[old]] = new
         self.sources = tuple(sources)
         if data_stream.axis_labels:
             kwargs.setdefault(

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -662,6 +662,10 @@ class TestRename(object):
         assert_raises(ValueError, Rename, self.stream,
                       {'X': 'features'}, on_non_existent='foo')
 
+    def test_raises_on_not_one_to_one(self):
+        assert_raises(KeyError, Rename, self.stream, {'X': 'features',
+                                                      'y': 'features'})
+
     def test_intentionally_ignore_missing(self):
         assert_equal(Rename(self.stream,
                             {'X': 'features', 'y': 'targets',

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -682,6 +682,13 @@ class TestRename(object):
                             on_non_existent='ignore').sources,
                      ('features', 'targets'))
 
+    def test_not_one_to_one_ok_if_not_a_source_in_data_stream(self):
+        assert_equal(Rename(self.stream,
+                            {'X': 'features', 'y': 'targets',
+                             'Z': 'targets'},
+                            on_non_existent='ignore').sources,
+                     ('features', 'targets'))
+
     def test_renames_axis_labels(self):
         assert_equal(self.transformer.axis_labels,
                      {'features': ('batch', 'width', 'height'),

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -665,6 +665,12 @@ class TestRename(object):
     def test_name_clash(self):
         assert_raises(KeyError, Rename, self.stream, {'X': 'y'})
 
+    def test_name_swap(self):
+        assert_equal(Rename(self.stream,
+                            {'X': 'y', 'y': 'X'},
+                            on_non_existent='ignore').sources,
+                     ('y', 'X'))
+
     def test_raises_on_not_one_to_one(self):
         assert_raises(KeyError, Rename, self.stream, {'X': 'features',
                                                       'y': 'features'})

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -658,6 +658,17 @@ class TestRename(object):
     def test_raises_error_on_nonexistent_source_name(self):
         assert_raises(KeyError, Rename, self.stream, {'Z': 'features'})
 
+    def test_raises_on_invalid_kwargs(self):
+        assert_raises(ValueError, Rename, self.stream,
+                      {'X': 'features'}, on_non_existent='foo')
+
+    def test_intentionally_ignore_missing(self):
+        assert_equal(Rename(self.stream,
+                            {'X': 'features', 'y': 'targets',
+                             'Z': 'fudgesicle'},
+                            on_non_existent='ignore').sources,
+                     ('features', 'targets'))
+
     def test_renames_axis_labels(self):
         assert_equal(self.transformer.axis_labels,
                      {'features': ('batch', 'width', 'height'),

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -662,6 +662,9 @@ class TestRename(object):
         assert_raises(ValueError, Rename, self.stream,
                       {'X': 'features'}, on_non_existent='foo')
 
+    def test_name_clash(self):
+        assert_raises(KeyError, Rename, self.stream, {'X': 'y'})
+
     def test_raises_on_not_one_to_one(self):
         assert_raises(KeyError, Rename, self.stream, {'X': 'features',
                                                       'y': 'features'})


### PR DESCRIPTION
New feature: allow the transformer to intentionally ignore sources in the rename dictionary that don't appear in the dataset.

Bug fixes:
* Only allow mappings that are one-to-one as many-to-one mappings make no sense (ab55194). Actually, only enforce this for sources that are actually present in the dataset (03d99b1).
* Don't let the Rename transformer rename a source to the name of another source (unless that other source is also being renamed). (c14cea6).
* Don't operate wholly in-place by looking up indices in a mutable list, as in certain cases this can lead to incorrect behaviour. (714feac).