### PR TITLE
Another Rename fix

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -901,10 +901,11 @@ class Rename(AgnosticTransformer):
         sources_lookup = {n: i for i, n in enumerate(sources)}
         for old, new in iteritems(names):
             if new in sources_lookup and new not in names:
-                message = ("Renaming source '{}' to '{}' "
-                           "would create two sources named '{}'"
-                           .format(old, new, new))
-                raise KeyError(message)
+                if old in usable_names:
+                    message = ("Renaming source '{}' to '{}' "
+                               "would create two sources named '{}'"
+                               .format(old, new, new))
+                    raise KeyError(message)
             if old not in sources_lookup:
                 message = ("Renaming source '{}' to '{}': "
                            "stream does not provide a source '{}'"

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -665,6 +665,15 @@ class TestRename(object):
     def test_name_clash(self):
         assert_raises(KeyError, Rename, self.stream, {'X': 'y'})
 
+    def test_not_really_a_name_clash(self):
+        try:
+            # This should not raise an error, because we're ignoring
+            # non-existent sources. So renaming a non-existent source
+            # cannot create a name clash.
+            Rename(self.stream, {'foobar': 'y'}, on_non_existent='ignore')
+        except KeyError:
+            assert False   # Regression.
+
     def test_name_swap(self):
         assert_equal(Rename(self.stream,
                             {'X': 'y', 'y': 'X'},


### PR DESCRIPTION
#355 didn't quite implement one case I was interested in: the ability to do many-to-one mappings when only one of the old source names exists. This fixes it and adds a test.