### PR TITLE
Add `copy` flag that enables a deep copy of the entire stream pipeline.

### DIFF
--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+import copy
 
 import zmq
 from six import add_metaclass, iteritems
@@ -42,9 +43,10 @@ class AbstractDataStream(object):
         of examples).
 
     """
-    def __init__(self, iteration_scheme=None, axis_labels=None):
+    def __init__(self, iteration_scheme=None, axis_labels=None, copy=False):
         self.iteration_scheme = iteration_scheme
         self.axis_labels = axis_labels
+        self.copy = copy
 
     @property
     def produces_examples(self):
@@ -92,8 +94,9 @@ class AbstractDataStream(object):
 
     @abstractmethod
     def get_epoch_iterator(self, as_dict=False):
-        return DataIterator(self, self.iteration_scheme.get_request_iterator()
-                            if self.iteration_scheme else None,
+        new_self = copy.deepcopy(self) if self.copy else self
+        return DataIterator(new_self, new_self.iteration_scheme.get_request_iterator()
+                            if new_self.iteration_scheme else None,
                             as_dict=as_dict)
 
     def iterate_epochs(self, as_dict=False):

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -749,9 +749,9 @@ class Merge(AbstractDataStream):
     ('Hello world!', 'Bonjour le monde!')
 
     """
-    def __init__(self, data_streams, sources, axis_labels=None):
+    def __init__(self, data_streams, sources, axis_labels=None, **kwargs):
         super(Merge, self).__init__(
-            iteration_scheme=None, axis_labels=axis_labels)
+            iteration_scheme=None, axis_labels=axis_labels, **kwargs)
         if not all(data_stream.produces_examples ==
                    data_streams[0].produces_examples
                    for data_stream in data_streams):


### PR DESCRIPTION
The flag introduced in this commit could be used to split a stream into multiple ones and use each branch independently. `AbstractDataStream` now accepts an optional flag `copy` which is `False` by default. When set to `True`, the `DataIterator` in the `AbstractDataStream.get_epoch_iterator` is always provided with a unique deep copy of the data stream.

In addition, `Merge` now accepts and forwards `**kwargs` to `AbstractDataStream` for compatibility reasons.

The following code demonstrates the unexpected behavior which could be avoided by using the `copy=True` flag. The code splits a stream of two variables into two independent streams. Then the streams are merged back into a single stream again. An expected behavior is that the resulting stream generates the same data as the original stream. However, this is not the case.

```python
import pprint
import numpy as np

from fuel.streams import DataStream
from fuel.datasets import IndexableDataset
from fuel.transformers import FilterSources, Merge
from fuel.schemes import ShuffledScheme, SequentialScheme


def print_stream(data_stream, msg):
    print(msg)
    for d in data_stream.get_epoch_iterator(as_dict=True):
        pprint.pprint(d, width=1)
        print('')
    print('----------------------')


if __name__ == '__main__':
    num_examples = 10

    x = np.tile(np.arange(num_examples), (3, 1)).T
    y = np.tile(np.arange(num_examples) + num_examples, (2, 1)).T

    dataset = IndexableDataset({'x': x, 'y': y})
    stream = DataStream(dataset=dataset, iteration_scheme=SequentialScheme(batch_size=3, examples=dataset.num_examples))
    print_stream(stream, 'After stream creation:')

    stream = FilterSources(stream, ('x', 'y'))
    print_stream(stream, 'After innocent filter:')

    x_only = FilterSources(stream, ('x',))
    y_only = FilterSources(stream, ('y',))
    stream = Merge([x_only, y_only], x_only.sources + y_only.sources)
    print_stream(stream, 'After merge:')
```