### PR TITLE
Make get_data optional in AbstractDataStream.

### DIFF
--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -67,7 +67,6 @@ class AbstractDataStream(object):
                                  self.iteration_scheme))
         self._produces_examples = value
 
-    @abstractmethod
     def get_data(self, request=None):
         """Request data from the dataset or the wrapped stream.
 
@@ -76,7 +75,14 @@ class AbstractDataStream(object):
         request : object
             A request fetched from the `request_iterator`.
 
+        Notes
+        -----
+        It is possible to build a usable stream in terms of underlying
+        streams for the purposes of training by only implementing
+        `get_epoch_iterator`, thus this method is optional.
+
         """
+        raise NotImplementedError
 
     @abstractmethod
     def reset(self):

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -84,15 +84,12 @@ class AbstractDataStream(object):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def reset(self):
         """Reset the data stream."""
 
-    @abstractmethod
     def close(self):
         """Gracefully close the data stream, e.g. releasing file handles."""
 
-    @abstractmethod
     def next_epoch(self):
         """Switch the data stream to the next epoch."""
 


### PR DESCRIPTION
I've noticed that it's often a lot more expedient to stub out `get_data` if all you care is epoch iterators, so we might as well make it an optional implement.