### PR TITLE
Check variables exists on finally.

### DIFF
--- a/fuel/converters/svhn.py
+++ b/fuel/converters/svhn.py
@@ -255,10 +255,11 @@ def convert_svhn_format_1(directory, output_directory,
             for split in splits:
                 fill_split(split, bar=bar)
     finally:
-        if os.path.isdir(TMPDIR):
+        if 'TMPDIR' in locals() and os.path.isdir(TMPDIR):
             shutil.rmtree(TMPDIR)
-        h5file.flush()
-        h5file.close()
+        if 'h5file' in locals():
+            h5file.flush()
+            h5file.close()
 
     return (output_path,)
 

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -564,7 +564,7 @@ class H5PYDataset(Dataset):
             raise ValueError()
         data = []
         shapes = []
-        # TODO: This is not an ideal solution, really unpickling should be 
+        # TODO: This is not an ideal solution, really unpickling should be
         # restoring the state of the dataset fully, i.e. load() must be
         # modified to account for the out-of-memory case.
         # See https://git.io/vKkSm


### PR DESCRIPTION
On Mac OSX, if convert_svhn_format_1 method's output_directory parameter is not exist on file system, 'no such file or directory' exception is ignored.

- as-is
```
import os
import tempfile
import h5py

# del TMPDIR
# TMPDIR=''
try:
    output_path = os.path.join('test', 'test.txt')
    h5file = h5py.File(output_path, mode='w')
    TMPDIR = tempfile.mkdtemp()
finally:
    if os.path.isdir(TMPDIR):
        shutil.rmtree(TMPDIR)
    h5file.flush()
    h5file.close()
```
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-23-e22f107cfbb3> in <module>()
     10     TMPDIR = tempfile.mkdtemp()
     11 finally:
---> 12     if os.path.isdir(TMPDIR):
     13         shutil.rmtree(TMPDIR)
     14     if locals():

NameError: name 'TMPDIR' is not defined
```

- to-be
```
import os
import tempfile
import h5py

try:
    output_path = os.path.join('svhn', 'test.txt')
    h5file = h5py.File(output_path, mode='w')
    TMPDIR = tempfile.mkdtemp()
finally:
    if 'TMPDIR' in locals() and os.path.isdir(TMPDIR):
        shutil.rmtree(TMPDIR)
    if 'h5file' in locals():
        h5file.flush()
        h5file.close()
```
```
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-19-a3df4e416499> in <module>()
      7 try:
      8     output_path = os.path.join('svhn', 'test.txt')
----> 9     h5file = h5py.File(output_path, mode='w')
     10     TMPDIR = tempfile.mkdtemp()
     11 finally:

/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/h5py/_hl/files.pyc in __init__(self, name, mode, driver, libver, userblock_size, swmr, **kwds)
    270 
    271                 fapl = make_fapl(driver, libver, **kwds)
--> 272                 fid = make_fid(name, mode, userblock_size, fapl, swmr=swmr)
    273 
    274                 if swmr_support:

/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/h5py/_hl/files.pyc in make_fid(name, mode, userblock_size, fapl, fcpl, swmr)
     96         fid = h5f.create(name, h5f.ACC_EXCL, fapl=fapl, fcpl=fcpl)
     97     elif mode == 'w':
---> 98         fid = h5f.create(name, h5f.ACC_TRUNC, fapl=fapl, fcpl=fcpl)
     99     elif mode == 'a':
    100         # Open in append mode (read/write).

h5py/_objects.pyx in h5py._objects.with_phil.wrapper (/Users/travis/build/MacPython/h5py-wheels/h5py/h5py/_objects.c:2687)()

h5py/_objects.pyx in h5py._objects.with_phil.wrapper (/Users/travis/build/MacPython/h5py-wheels/h5py/h5py/_objects.c:2645)()

h5py/h5f.pyx in h5py.h5f.create (/Users/travis/build/MacPython/h5py-wheels/h5py/h5py/h5f.c:2100)()

IOError: Unable to create file (Unable to open file: name = 'svhn/test.txt', errno = 2, error message = 'no such file or directory', flags = 13, o_flags = 602)
```
