### PR TITLE
Make mapping transformer accept dictionary

### DIFF
--- a/docs/api/transformers.rst
+++ b/docs/api/transformers.rst
@@ -25,3 +25,10 @@ Transformers for sequences
     :undoc-members:
     :show-inheritance:
 
+Other
+-----
+
+.. automodule:: fuel.transformers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,0 +1,7 @@
+Utilities
+=========
+
+.. automodule:: fuel.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -199,7 +199,7 @@ class Mapping(Transformer):
         This behavior can be changed by annotating_ the mapping's input as a
         dictionary.
 
-        Convenience functions :func:`~.accepts_dict` and 
+        Convenience functions :func:`~.accepts_dict` and
         :func:`~.accepts_list` are provided for annotating with legacy python.
     add_sources : tuple of str, optional
         When given, the data produced by the mapping is added to original

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -192,10 +192,21 @@ class Mapping(Transformer):
     data_stream : instance of :class:`DataStream`
         The wrapped data stream.
     mapping : callable
-        The mapping to be applied.
+        The mapping to be applied. The mapping function is supposed
+        to accept a tuple and return a tuple by default. It is possible
+        change this behavior by annotating_ the input as a dictionary.
+        In this case the mapping function is provided an ordered 
+        dictionary with source names as keys.
+
+        Convenience functions :func:`~.accepts_dict` and 
+        :func:`~.accepts_list` are provided for using with legacy python.
     add_sources : tuple of str, optional
         When given, the data produced by the mapping is added to original
         data under source names `add_sources`.
+
+
+    .. _annotating: https://docs.python.org/3.6/tutorial/
+                    controlflow.html#function-annotations
 
     """
     def __init__(self, data_stream, mapping, add_sources=None, **kwargs):

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -196,46 +196,25 @@ class Mapping(Transformer):
         to accept a tuple and return a tuple by default. If
         `mapping_accepts` is set to `dict`, the function is expected to
         work with ordered dictionaries where source names are the keys.
-        This behavior can be changed by annotating_ the mapping's input as
-        a dictionary.
-
-        Convenience functions :func:`~.accepts_dict` and
-        :func:`~.accepts_list` are provided for annotating with legacy
-        python.
     add_sources : tuple of str, optional
         When given, the data produced by the mapping is added to original
         data under source names `add_sources`.
     mapping_accepts : type, optional
-        Can be `list` or `dict`.
-
-
-    .. _annotating: https://docs.python.org/3.6/tutorial/
-                    controlflow.html#function-annotations
+        Input and output type of the mapping function `list` by default,
+        can be changed to `dict`.
 
     """
     def __init__(self, data_stream, mapping, add_sources=None,
-                 mapping_accepts=None, **kwargs):
+                 mapping_accepts=list, **kwargs):
         super(Mapping, self).__init__(
             data_stream, data_stream.produces_examples, **kwargs)
-        if mapping_accepts is not None:
-            self.mapping_accepts = mapping_accepts
-        else:
-            self._configure_mapping(mapping)
+        if mapping_accepts not in [list, dict]:
+            raise ValueError('`Mapping` can accept `list` or `dict`, not `{}`'
+                             .format(mapping_accepts))
+
+        self.mapping_accepts = mapping_accepts
         self.mapping = mapping
         self.add_sources = add_sources
-
-    def _configure_mapping(self, mapping):
-        annotations = getattr(mapping, '__annotations__', {None: list})
-        annotations.pop('return', None)
-        if len(annotations) > 1:
-            raise ValueError('`mapping` function should accept one argument')
-        if annotations:
-            self.mapping_accepts = list(annotations.values())[0]
-        else:
-            self.mapping_accepts = list
-        if self.mapping_accepts not in [list, dict]:
-            raise ValueError('`mapping` function should accept `list` or'
-                             '`dict`, not `{}`'.format(self.mapping_accepts))
 
     @property
     def sources(self):

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -193,14 +193,15 @@ class Mapping(Transformer):
         The wrapped data stream.
     mapping : callable
         The mapping to be applied. The mapping function is supposed
-        to accept a tuple and return a tuple by default. If `mapping_accepts`
-        is set to `dict`, the function is expected to work with ordered
-        dictionaries where source names are the keys.
-        This behavior can be changed by annotating_ the mapping's input as a
-        dictionary.
+        to accept a tuple and return a tuple by default. If
+        `mapping_accepts` is set to `dict`, the function is expected to
+        work with ordered dictionaries where source names are the keys.
+        This behavior can be changed by annotating_ the mapping's input as
+        a dictionary.
 
         Convenience functions :func:`~.accepts_dict` and
-        :func:`~.accepts_list` are provided for annotating with legacy python.
+        :func:`~.accepts_list` are provided for annotating with legacy
+        python.
     add_sources : tuple of str, optional
         When given, the data produced by the mapping is added to original
         data under source names `add_sources`.

--- a/fuel/utils/__init__.py
+++ b/fuel/utils/__init__.py
@@ -518,7 +518,7 @@ def _func_annotation_for(func):
     current = getattr(func, '__annotations__', None)
     if current is None:
         current = func.__annotations__ = {}
-    return current 
+    return current
 
 
 def accepts_list(function):

--- a/fuel/utils/__init__.py
+++ b/fuel/utils/__init__.py
@@ -511,3 +511,23 @@ def do_not_pickle_attributes(*lazy_properties):
 
         return cls
     return wrap_class
+
+
+def _func_annotation_for(func):
+    """Retrieve the function annotation for a given function or create it"""
+    current = getattr(func, '__annotations__', None)
+    if current is None:
+        current = func.__annotations__ = {}
+    return current 
+
+
+def accepts_list(function):
+    base = _func_annotation_for(function)
+    base.update({None: list})
+    return function
+
+
+def accepts_dict(function):
+    base = _func_annotation_for(function)
+    base.update({None: dict})
+    return function

--- a/fuel/utils/__init__.py
+++ b/fuel/utils/__init__.py
@@ -511,25 +511,3 @@ def do_not_pickle_attributes(*lazy_properties):
 
         return cls
     return wrap_class
-
-
-def _func_annotation_for(func):
-    """Retrieve the function annotation for a given function or create it."""
-    current = getattr(func, '__annotations__', None)
-    if current is None:
-        current = func.__annotations__ = {}
-    return current
-
-
-def accepts_list(function):
-    """A decorator to add an annotation that the input is a list."""
-    base = _func_annotation_for(function)
-    base.update({None: list})
-    return function
-
-
-def accepts_dict(function):
-    """A decorator to add an annotation that the input is a dict."""
-    base = _func_annotation_for(function)
-    base.update({None: dict})
-    return function

--- a/fuel/utils/__init__.py
+++ b/fuel/utils/__init__.py
@@ -522,12 +522,14 @@ def _func_annotation_for(func):
 
 
 def accepts_list(function):
+    """A decorator to add an annotation that the input is a list"""
     base = _func_annotation_for(function)
     base.update({None: list})
     return function
 
 
 def accepts_dict(function):
+    """A decorator to add an annotation that the input is a dict"""
     base = _func_annotation_for(function)
     base.update({None: dict})
     return function

--- a/fuel/utils/__init__.py
+++ b/fuel/utils/__init__.py
@@ -514,7 +514,7 @@ def do_not_pickle_attributes(*lazy_properties):
 
 
 def _func_annotation_for(func):
-    """Retrieve the function annotation for a given function or create it"""
+    """Retrieve the function annotation for a given function or create it."""
     current = getattr(func, '__annotations__', None)
     if current is None:
         current = func.__annotations__ = {}
@@ -522,14 +522,14 @@ def _func_annotation_for(func):
 
 
 def accepts_list(function):
-    """A decorator to add an annotation that the input is a list"""
+    """A decorator to add an annotation that the input is a list."""
     base = _func_annotation_for(function)
     base.update({None: list})
     return function
 
 
 def accepts_dict(function):
-    """A decorator to add an annotation that the input is a dict"""
+    """A decorator to add an annotation that the input is a dict."""
     base = _func_annotation_for(function)
     base.update({None: dict})
     return function

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -16,7 +16,7 @@ from fuel.transformers import (
     Cache, Batch, Padding, MultiProcessing, Unpack, Merge,
     SourcewiseTransformer, Flatten, ScaleAndShift, Cast, Rename, FilterSources)
 from fuel.transformers.defaults import ToBytes
-from fuel.utils import accepts_dict
+from fuel.utils import accepts_dict, accepts_list
 
 
 class FlagDataStream(DataStream):
@@ -93,6 +93,15 @@ class TestMapping(object):
         @accepts_dict
         def mapping(d):
             return [2 * i for i in d['data']],
+        stream = DataStream(IterableDataset(self.data))
+        transformer = Mapping(stream, mapping)
+        assert_equal(list(transformer.get_epoch_iterator()),
+                     list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
+
+    def test_mapping_accepts_list(self):
+        @accepts_list
+        def mapping(d):
+            return [2 * i for i in d[0]],
         stream = DataStream(IterableDataset(self.data))
         transformer = Mapping(stream, mapping)
         assert_equal(list(transformer.get_epoch_iterator()),

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -16,7 +16,6 @@ from fuel.transformers import (
     Cache, Batch, Padding, MultiProcessing, Unpack, Merge,
     SourcewiseTransformer, Flatten, ScaleAndShift, Cast, Rename, FilterSources)
 from fuel.transformers.defaults import ToBytes
-from fuel.utils import accepts_dict, accepts_list
 
 
 class FlagDataStream(DataStream):
@@ -90,36 +89,20 @@ class TestMapping(object):
                      list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
 
     def test_mapping_dict(self):
-        @accepts_dict
         def mapping(d):
             return {'data': [2 * i for i in d['data']]}
-        stream = DataStream(IterableDataset(self.data))
-        transformer = Mapping(stream, mapping)
-        assert_equal(list(transformer.get_epoch_iterator()),
-                     list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
 
         stream = DataStream(IterableDataset(self.data))
         transformer = Mapping(stream, mapping, mapping_accepts=dict)
         assert_equal(list(transformer.get_epoch_iterator()),
                      list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
 
-    def test_mapping_accepts_list(self):
-        @accepts_list
+    def test_mapping_accepts_list_or_dict(self):
         def mapping(d):
             return [2 * i for i in d[0]],
         stream = DataStream(IterableDataset(self.data))
-        transformer = Mapping(stream, mapping)
-        assert_equal(list(transformer.get_epoch_iterator()),
-                     list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
-
-    def test_mapping_incorrect_annotation(self):
-        def mapping(d):
-            return {'data': [2 * i for i in d['data']]}
-        mapping.__annotations__ = {'d': list, 'c': list}
-        stream = DataStream(IterableDataset(self.data))
-        assert_raises(ValueError, lambda: Mapping(stream, mapping))
-        mapping.__annotations__ = {'d': 'list'}
-        assert_raises(ValueError, lambda: Mapping(stream, mapping))
+        assert_raises(ValueError,
+                      lambda: Mapping(stream, mapping, mapping_accepts=int))
 
     def test_add_sources(self):
         stream = DataStream(IterableDataset(self.data))

--- a/tests/transformers/test_transformers.py
+++ b/tests/transformers/test_transformers.py
@@ -92,9 +92,14 @@ class TestMapping(object):
     def test_mapping_dict(self):
         @accepts_dict
         def mapping(d):
-            return [2 * i for i in d['data']],
+            return {'data': [2 * i for i in d['data']]}
         stream = DataStream(IterableDataset(self.data))
         transformer = Mapping(stream, mapping)
+        assert_equal(list(transformer.get_epoch_iterator()),
+                     list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
+
+        stream = DataStream(IterableDataset(self.data))
+        transformer = Mapping(stream, mapping, mapping_accepts=dict)
         assert_equal(list(transformer.get_epoch_iterator()),
                      list(zip([[2, 4, 6], [4, 6, 2], [6, 4, 2]])))
 
@@ -109,12 +114,12 @@ class TestMapping(object):
 
     def test_mapping_incorrect_annotation(self):
         def mapping(d):
-            return [2 * i for i in d['data']],
+            return {'data': [2 * i for i in d['data']]}
         mapping.__annotations__ = {'d': list, 'c': list}
         stream = DataStream(IterableDataset(self.data))
-        assert_raises(ValueError, lambda : Mapping(stream, mapping))
+        assert_raises(ValueError, lambda: Mapping(stream, mapping))
         mapping.__annotations__ = {'d': 'list'}
-        assert_raises(ValueError, lambda : Mapping(stream, mapping))
+        assert_raises(ValueError, lambda: Mapping(stream, mapping))
 
     def test_add_sources(self):
         stream = DataStream(IterableDataset(self.data))


### PR DESCRIPTION
I frequently feel frustrated that when I change my data pipeline some mapping transformer in the middle receives a different number of arguments. Now it is possible to work with a dictionary rather than with a tuple:

```python
# Easiest way to use
def double_square(data):
    return {'features': 2 * data['features'], 'targets': (data['targets']) ** 2}
stream = Mapping(stream, double_square, mapping_accepts=dict)
```

Fixes #372.