### PR TITLE
Don't import Theano

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update -q --yes conda
   - export FUEL_DATA_PATH=$TRAVIS_BUILD_DIR/data
+  - export FUEL_FLOATX=float64
 install:
   # Install all Python dependencies
   - |

--- a/fuel/config_parser.py
+++ b/fuel/config_parser.py
@@ -196,14 +196,6 @@ config.add_config('extra_downloaders', type_=extra_downloader_converter,
                   default=[], env_var='FUEL_EXTRA_DOWNLOADERS')
 config.add_config('extra_converters', type_=extra_downloader_converter,
                   default=[], env_var='FUEL_EXTRA_CONVERTERS')
-
-# Default to Theano's floatX if possible
-try:
-    from theano import config as theano_config
-    default_floatX = theano_config.floatX
-except Exception:
-    default_floatX = 'float64'
-config.add_config('floatX', type_=str, env_var='FUEL_FLOATX',
-                  default=default_floatX)
+config.add_config('floatX', type_=str, env_var='FUEL_FLOATX')
 
 config.load_yaml()

--- a/fuel/config_parser.py
+++ b/fuel/config_parser.py
@@ -186,6 +186,7 @@ class Configuration(object):
         if default is not NOT_SET:
             self.config[key]['default'] = default
 
+
 config = Configuration()
 
 # Define configuration options


### PR DESCRIPTION
Fuel should not import Theano. Right now if I run  Fuel data server in the same shell where I run my training job, it ends up occupying another GPU because `device` in `THEANO_FLAGS` is set to GPU. This basically makes it impossible to use Fuel server with slurm.

On the other hand, we should notify the users after this PR, because they will have to set `floatX` in their `~/.fuelrc` explicitly.

@bartvm 