### PR TITLE
fix pickling ServerDataStream and make it lazy

### DIFF
--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -219,7 +219,7 @@ class ServerDataStream(AbstractDataStream):
         self.host = host
         self.port = port
         self.hwm = hwm
-        self.connect()
+        self.connected = False
 
     def connect(self):
         context = zmq.Context()
@@ -251,5 +251,6 @@ class ServerDataStream(AbstractDataStream):
     def __getstate__(self):
         state = self.__dict__.copy()
         state['connected'] = False
-        del state['socket']
+        if 'socket' in state:
+            del state['socket']
         return state

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,6 +37,8 @@ class TestServer(object):
     def test_pickling(self):
         try:
             self.stream = cPickle.loads(cPickle.dumps(self.stream))
+            # regression test: pickling of an unpickled stream used it fail
+            cPickle.dumps(self.stream)
             server_data = self.stream.get_epoch_iterator()
             expected_data = get_stream().get_epoch_iterator()
             for _, s, e in zip(range(3), server_data, expected_data):


### PR DESCRIPTION
Two changes:
- pickling an unpickled stream used to fail
- I would really like `ServerDataStream` to postpone establishing the connection until it's really necessary for flexibility reasons. Also, it was kind of asymmetric so far that in during the construction it connects immediately but it doesn't so when unpickled.