### PR TITLE
Introduce `source_shapes` for H5PYDataset

### DIFF
--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -488,13 +488,29 @@ class H5PYDataset(Dataset):
                     shapes = None
                 source_shapes.append(shapes)
             self.data_sources = tuple(data_sources)
+            # TODO why is this a tuple, while `.sources` is a list?
             self.source_shapes = tuple(source_shapes)
             # This exists only for request sanity checking purposes.
             self.in_memory_subset = Subset(
                 slice(None), len(self.data_sources[0]))
         else:
+            # I have a feeling we can probably get data shapes in a single way
+            # regardless of whether data is in memory or not
+            source_shapes = []
+            for source_name, subset in zip(self.sources, self.subsets):
+                # Reuse this use case from a few lines up
+                if source_name in self.vlen_sources:
+                    shapes = subset.index_within_subset(
+                        handle[source_name].dims[0]['shapes'],
+                        slice(None))
+                else:
+                    if self.user_given_subset != slice(None):
+                        raise NotImplementedError('Not entirely sure how to handle user slices yet')
+                    shapes = handle[source_name].shape
+                source_shapes.append(shapes)
+
+            self.source_shapes = source_shapes
             self.data_sources = None
-            self.source_shapes = None
             self.in_memory_subset = None
 
         self._out_of_memory_close()


### PR DESCRIPTION
This pull request is meant to initiate discussion and is by no means finished.

I needed to get the dimensions of my data before reading any data from my HDF5 files. There is the `num_examples` attribute but of course that's only limited to one dimension. I could not find any straightforward way to get all dimensions.. except `H5PYDataset.source_shapes` seemed to represent what I wanted. But it wasn't really implemented. So it might very well be that I missed a way of getting my sources' dimensions but in the meantime I've implemented the `source_shapes` attribute to accomplish what I need, albeit in not all possible scenarios.

If you agree that this `source_shapes` attribute is useful, I could look into how to complete the feature because currently it only works if the user has provided no custom slices (which suits my use case just fine for now).