### PR TITLE
Fixed caching autodoc (failed to build). Added link to cache_file.

### DIFF
--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -10,6 +10,6 @@ Caching
 -------
 
 .. automodule:: fuel.utils.cache
-:members:
-        :undoc-members:
-        :show-inheritance:
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -19,7 +19,4 @@ This variable can also be set through an environment variable as follows:
 
 Please note that currently, caching is only implemented in the ``H5PyDataset``.
 In order to add caching to other types of datasets, one should use the
-|cache_file|_ function.
-
-.. |cache_file| replace:: ``cache_file``
-.. _cache_file: api/utils.html#fuel.utils.cache.cache_file
+:func:`fuel.utils.cache.cache_file` function.

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -15,7 +15,7 @@ This variable can also be set through an environment variable as follows:
 
 .. code-block:: bash
 
-    $ export FUEL_LOCAL_DATA_PATH="/home/username/my_local_cache"
+    $ export FUEL_LOCAL_DATA_PATH="/LOCAL_PATH/my_local_cache"
 
 Please note that currently, caching is only implemented in the ``H5PyDataset``.
 In order to add caching to other types of datasets, one should use the

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -19,4 +19,7 @@ This variable can also be set through an environment variable as follows:
 
 Please note that currently, caching is only implemented in the ``H5PyDataset``.
 In order to add caching to other types of datasets, one should use the
-``cache_file`` function, which is defined in ``fuel/utils/cache.py``.
+|cache_file|_ function.
+
+.. |cache_file| replace:: ``cache_file``
+.. _cache_file: api/utils.html#fuel.utils.cache.cache_file


### PR DESCRIPTION
Added links to the `cache_file` source documentation. Fixed formatting error which prevented the `fuel.utils.cache` source docs from building.